### PR TITLE
Fullname should be provided to nip05's queryProfile

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ import 'websocket-polyfill'
 ```js
 import {nip05} from 'nostr-tools'
 
-let profile = await nip05.queryProfile('jb55.com')
+let profile = await nip05.queryProfile('jb55@jb55.com')
 console.log(profile.pubkey)
 // prints: 32e1827635450ebb3c5a7d12c1f8e7b2b514439ac10a67eef3d9fd9c5c68e245
 console.log(profile.relays)


### PR DESCRIPTION
When using queryProfile from nip05, you should provide a fullname, not just the @domain part, so I'm "fixing" the example here.