### PR TITLE
nip05 supports uppercase

### DIFF
--- a/nip05.ts
+++ b/nip05.ts
@@ -36,7 +36,7 @@ export async function queryProfile(
     name = '_'
   }
 
-  if (!name.match(/^[a-z0-9-_]+$/)) return null
+  if (!name.match(/^[A-Za-z0-9-_]+$/)) return null
 
   let res = await (
     await _fetch(`https://${domain}/.well-known/nostr.json?name=${name}`)


### PR DESCRIPTION
nip05 says `NIP-05 assumes the <local-part> part will be restricted to the characters a-z0-9-_., case insensitive`

So a lot of people is starting the names with uppercase. See here:

https://nostr-check.com/.well-known/nostr.json

So I think we should change the regex to accept lowercase or uppercase.

Another way to do it would be to do a `.toLowerCase` at the beginning, but then we would need to do this search ignoring the case:

```
if (!res?.names?.[name])
```

So maybe for now this is enough?