### PR TITLE
Add field `aliases` to `ProfilePointer` for nip05

### DIFF
--- a/nip05.ts
+++ b/nip05.ts
@@ -46,9 +46,11 @@ export async function queryProfile(
 
   let pubkey = res.names[name] as string
   let relays = (res.relays?.[pubkey] || []) as string[] // nip35
+  let aliases = Object.keys(res.names).filter(k => res.names[k] === pubkey)
 
   return {
     pubkey,
-    relays
+    relays,
+    aliases
   }
 }

--- a/nip19.ts
+++ b/nip19.ts
@@ -8,6 +8,7 @@ const Bech32MaxSize = 5000
 export type ProfilePointer = {
   pubkey: string // hex
   relays?: string[]
+  aliases?: string[]
 }
 
 export type EventPointer = {


### PR DESCRIPTION
In NIP-05, there may be multiple names corresponding to the same Pubkey in `nostr.json`. For example:
```json
{
  "names": {
    "jb55": "32e1827635450ebb3c5a7d12c1f8e7b2b514439ac10a67eef3d9fd9c5c68e245",
    "minebot": "6cad545430904b84a8101c5783b65043f19ae29d2da1076b8fc3e64892736f03",
    "_": "32e1827635450ebb3c5a7d12c1f8e7b2b514439ac10a67eef3d9fd9c5c68e245"
  }
}
```
This may be for compatibility purposes. And In some client implementations, only the domain name part is displayed for nip05, which has some risks. Once the attacker has obtained the identity of nip05 (or a privatekey, such as `minebot` in this case) under the same domain name, he can modify his profile to disguise as anyone with the same domain name.

So in the future, the client may have to highlight when the name of the profile is inconsistent with the name of nip05. But the real owner, if you use `_@domain` will be treated wrongly. Therefore, if the alias is obtained at the same time of verification, it will help to handle it correctly. For example:

```javascript
nip05.queryProfile('jb55.com');
```
and
```javascript
nip05.queryProfile('jb55@jb55.com');
```

Both will get:
```javascript
{
  pubkey: '32e1827635450ebb3c5a7d12c1f8e7b2b514439ac10a67eef3d9fd9c5c68e245',
  aliases: ['jb55', '_']
}
```