### PR TITLE
Make `esm` bundle usable in node 

### DIFF
--- a/build.js
+++ b/build.js
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 
+const fs = require('fs')
 const esbuild = require('esbuild')
 
 let common = {
@@ -11,11 +12,16 @@ let common = {
 esbuild
   .build({
     ...common,
-    outfile: 'lib/nostr.esm.js',
+    outfile: 'lib/esm/nostr.mjs',
     format: 'esm',
     packages: 'external'
   })
-  .then(() => console.log('esm build success.'))
+  .then(() => {
+    const packageJson = JSON.stringify({ type: 'module' })
+    fs.writeFileSync(`${__dirname}/lib/esm/package.json`, packageJson, 'utf8')
+
+    console.log('esm build success.')
+  })
 
 esbuild
   .build({

--- a/package.json
+++ b/package.json
@@ -7,7 +7,11 @@
     "url": "https://github.com/fiatjaf/nostr-tools.git"
   },
   "main": "lib/nostr.cjs.js",
-  "module": "lib/nostr.esm.js",
+  "module": "lib/esm/nostr.mjs",
+  "exports": {
+    "import": "./lib/esm/nostr.mjs",
+    "require": "./lib/nostr.cjs.js"
+  },
   "dependencies": {
     "@noble/hashes": "1.0.0",
     "@noble/secp256k1": "^1.7.1",


### PR DESCRIPTION
esm imports don't work currently because node decides whether a package is cjs or esm based on the `type` property in the nearest `package.json`. default value of `type` is `commonjs` which causes import/require import whatever is set for `main` which happens to be the cjs bundle. 


This PR fixes #124  by:
* auto-generating a minimal `package.json in `lib` dir nearest the esm bundle
  * Noticed this package uses `cjs` bundle in all tests so adding `type: "module"` to root package.json would cause things to break.
* including the `exports` property in the root package.json to allow node environments to use cjs or esm bundles 