### PR TITLE
ensure kind has type 'number' in validateEvent

### DIFF
--- a/event.ts
+++ b/event.ts
@@ -80,6 +80,7 @@ export function getEventHash(event: UnsignedEvent): string {
 
 export function validateEvent(event: UnsignedEvent): boolean {
   if (typeof event !== 'object') return false
+  if (typeof event.kind !== 'number') return false
   if (typeof event.content !== 'string') return false
   if (typeof event.created_at !== 'number') return false
   if (typeof event.pubkey !== 'string') return false


### PR DESCRIPTION
Stumbled across this oversight when wondering why `nostr-tools` was validating my event but relays were rejecting it. Thanks for building this & nostr!