### PR TITLE
Fixed readme for publishing with pool

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,11 +154,10 @@ sub.on('event', event => {
 })
 
 let pubs = pool.publish(relays, newEvent)
-pubs.forEach(pub =>
-  pub.on('ok', () => {
-    // ...
-  })
-)
+pubs.on('ok', () => {
+  // this may be called multiple times, once for every relay that accepts the event
+  // ...
+})
 
 let events = await pool.list(relays, [{kinds: [0, 1]}])
 let event = await pool.get(relays, {


### PR DESCRIPTION
pool.publish does not return an array, but instead an object with two methods: 'on' and 'off'. Updated README.md to show how to handle "ok" events that follow pool.publish. 