### PR TITLE
close relay's websocket only if it's in state OPEN

### DIFF
--- a/relay.ts
+++ b/relay.ts
@@ -310,8 +310,9 @@ export function relayInit(
       listeners = {connect: [], disconnect: [], error: [], notice: []}
       subListeners = {}
       pubListeners = {}
-
-      ws?.close()
+      if (ws.readyState === WebSocket.OPEN) {
+        ws?.close()
+      }
     },
     get status() {
       return ws?.readyState ?? 3


### PR DESCRIPTION
### Motivation

test `pool.test.js` was failing with error `TypeError: Cannot read properties of undefined (reading 'sendCloseFrame')`.
seems that (at least one) of the relays in the `relays` array is forcefully closing the connection, which was causing the error mentioned above, when trying to close the pool in `afterAll`.

`jest` was not exiting due to some websockets left unclosed. I think this is the reason that GitHub Actions workflow `test` has been failing recently (by exceeding the maximum execution time).

![jest-fail](https://user-images.githubusercontent.com/44037130/222914064-4830d325-119c-47d8-afd1-16cab6a49d92.png)
