### PR TITLE
Add .connect() to ensureRelay if connection exists, but status != 1

### DIFF
--- a/pool.ts
+++ b/pool.ts
@@ -27,7 +27,12 @@ export class SimplePool {
   async ensureRelay(url: string): Promise<Relay> {
     const nm = normalizeURL(url)
     const existing = this._conn[nm]
-    if (existing) return existing
+    if (existing && existing.status === 1) return existing
+
+    if (existing) {
+      await existing.connect();
+      return existing
+    }
 
     const relay = relayInit(nm, {
       getTimeout: this.getTimeout * 0.9,


### PR DESCRIPTION
I noticed that SimplePool runs into issues if the conenction is cut off at any time. This is because ensureRelays checks if the connection already exists, but does not ensure that the connection is acutally open. With this small addition ensureRelay will check if a requested connection already exists inside SimplePool and will attempt to re-open is status does not equal 1