### PR TITLE
add 17 test cases for event.js

### DIFF
--- a/event.test.js
+++ b/event.test.js
@@ -307,5 +307,34 @@ describe('Event', () => {
       expect(sig.length).toEqual(128)
       expect(isValid).toEqual(true)
     })
+
+    it('should not sign an event with different private key', () => {
+      const privateKey =
+        'd217c1ff2f8a65c3e3a1740db3b9f58b8c848bb45e26d00ed4714e4a0f4ceecf'
+      const publicKey = getPublicKey(privateKey)
+
+      const wrongPrivateKey =
+        'a91e2a9d9e0f70f0877bea0dbf034e8f95d7392a27a7f07da0d14b9e9d456be7'
+
+      const unsignedEvent = {
+        kind: Kind.Text,
+        tags: [],
+        content: 'Hello, world!',
+        created_at: 1617932115,
+        pubkey: publicKey
+      }
+
+      const sig = signEvent(unsignedEvent, wrongPrivateKey)
+
+      // verify the signature
+      const isValid = verifySignature({
+        ...unsignedEvent,
+        sig
+      })
+
+      expect(typeof sig).toEqual('string')
+      expect(sig.length).toEqual(128)
+      expect(isValid).toEqual(false)
+    })
   })
 })


### PR DESCRIPTION
### Added 17 test cases for event.js described as below:

**getBlankEvent** should return a blank event object.

**finishEvent** should create a signed event from a template.

**serializeEvent** should serialize a valid event object.
**serializeEvent**  should throw an error for an invalid event object.

**getEventHash** should return the correct event hash.

**validateEvent** should return true for a valid event object.
**validateEvent** should return false for a non object event.
**validateEvent** should return false for an event object with missing properties.
**validateEvent** should return false for an empty object.
**validateEvent** should return false for an object with invalid properties.
**validateEvent** should return false for an object with an invalid public key.
**validateEvent** should return false for an object with invalid tags.

**verifySignature** should return true for a valid event signature.
**verifySignature** should return false for an invalid event signature.
**verifySignature** should return false when verifying an event with a different private key.

**signEvent** should sign an event object.
**signEvent** should not sign an event with different private key.