### PR TITLE
edit filter.test.js and add more test cases

### DIFF
--- a/event.test.js
+++ b/event.test.js
@@ -307,5 +307,34 @@ describe('Event', () => {
       expect(sig.length).toEqual(128)
       expect(isValid).toEqual(true)
     })
+
+    it('should not sign an event with different private key', () => {
+      const privateKey =
+        'd217c1ff2f8a65c3e3a1740db3b9f58b8c848bb45e26d00ed4714e4a0f4ceecf'
+      const publicKey = getPublicKey(privateKey)
+
+      const wrongPrivateKey =
+        'a91e2a9d9e0f70f0877bea0dbf034e8f95d7392a27a7f07da0d14b9e9d456be7'
+
+      const unsignedEvent = {
+        kind: Kind.Text,
+        tags: [],
+        content: 'Hello, world!',
+        created_at: 1617932115,
+        pubkey: publicKey
+      }
+
+      const sig = signEvent(unsignedEvent, wrongPrivateKey)
+
+      // verify the signature
+      const isValid = verifySignature({
+        ...unsignedEvent,
+        sig
+      })
+
+      expect(typeof sig).toEqual('string')
+      expect(sig.length).toEqual(128)
+      expect(isValid).toEqual(false)
+    })
   })
 })

--- a/filter.test.js
+++ b/filter.test.js
@@ -1,42 +1,176 @@
 /* eslint-env jest */
 
-const {matchFilters} = require('./lib/nostr.cjs')
+const {matchFilter, matchFilters} = require('./lib/nostr.cjs.js')
 
-test('test if filters match', () => {
-  ;[
-    {
-      filters: [{ids: ['i']}],
-      good: [{id: 'i'}],
-      bad: [{id: 'j'}]
-    },
-    {
-      filters: [{authors: ['abc']}, {kinds: [1, 3]}],
-      good: [
-        {pubkey: 'xyz', kind: 3},
-        {pubkey: 'abc', kind: 12},
-        {pubkey: 'abc', kind: 1}
-      ],
-      bad: [{pubkey: 'hhh', kind: 12}]
-    },
-    {
-      filters: [{'#e': ['yyy'], since: 444}],
-      good: [
-        {
-          tags: [
-            ['e', 'uuu'],
-            ['e', 'yyy']
-          ],
-          created_at: 555
-        }
-      ],
-      bad: [{tags: [['e', 'uuu']], created_at: 111}]
-    }
-  ].forEach(({filters, good, bad}) => {
-    good.forEach(ev => {
-      expect(matchFilters(filters, ev)).toBeTruthy()
+describe('Filter', () => {
+  describe('matchFilter', () => {
+    it('should return true when all filter conditions are met', () => {
+      const filter = {
+        ids: ['123', '456'],
+        kinds: [1, 2, 3],
+        authors: ['abc'],
+        since: 100,
+        until: 200,
+        '#tag': ['value']
+      }
+
+      const event = {
+        id: '123',
+        kind: 1,
+        pubkey: 'abc',
+        created_at: 150,
+        tags: [['tag', 'value']]
+      }
+
+      const result = matchFilter(filter, event)
+
+      expect(result).toEqual(true)
     })
-    bad.forEach(ev => {
-      expect(matchFilters(filters, ev)).toBeFalsy()
+
+    it('should return false when the event id is not in the filter', () => {
+      const filter = {ids: ['123', '456']}
+
+      const event = {id: '789'}
+
+      const result = matchFilter(filter, event)
+
+      expect(result).toEqual(false)
+    })
+
+    it('should return false when the event kind is not in the filter', () => {
+      const filter = {kinds: [1, 2, 3]}
+
+      const event = {kind: 4}
+
+      const result = matchFilter(filter, event)
+
+      expect(result).toEqual(false)
+    })
+
+    it('should return false when the event author is not in the filter', () => {
+      const filter = {authors: ['abc', 'def']}
+
+      const event = {pubkey: 'ghi'}
+
+      const result = matchFilter(filter, event)
+
+      expect(result).toEqual(false)
+    })
+
+    it('should return false when a tag is not present in the event', () => {
+      const filter = {'#tag': ['value1', 'value2']}
+
+      const event = {tags: [['not_tag', 'value1']]}
+
+      const result = matchFilter(filter, event)
+
+      expect(result).toEqual(false)
+    })
+
+    it('should return false when a tag value is not present in the event', () => {
+      const filter = {'#tag': ['value1', 'value2']}
+
+      const event = {tags: [['tag', 'value3']]}
+
+      const result = matchFilter(filter, event)
+
+      expect(result).toEqual(false)
+    })
+
+    it('should return true when filter has tags that is present in the event', () => {
+      const filter = {'#tag1': ['foo']}
+
+      const event = {
+        id: '123',
+        kind: 1,
+        pubkey: 'abc',
+        created_at: 150,
+        tags: [
+          ['tag1', 'foo'],
+          ['tag2', 'bar']
+        ]
+      }
+
+      const result = matchFilter(filter, event)
+
+      expect(result).toEqual(true)
+    })
+
+    it('should return false when the event is before the filter since value', () => {
+      const filter = {since: 100}
+
+      const event = {created_at: 50}
+
+      const result = matchFilter(filter, event)
+
+      expect(result).toEqual(false)
+    })
+
+    it('should return false when the event is after the filter until value', () => {
+      const filter = {until: 100}
+
+      const event = {created_at: 150}
+
+      const result = matchFilter(filter, event)
+
+      expect(result).toEqual(false)
+    })
+  })
+
+  describe('matchFilters', () => {
+    it('should return true when at least one filter matches the event', () => {
+      const filters = [
+        {ids: ['123'], kinds: [1], authors: ['abc']},
+        {ids: ['456'], kinds: [2], authors: ['def']},
+        {ids: ['789'], kinds: [3], authors: ['ghi']}
+      ]
+
+      const event = {id: '789', kind: 3, pubkey: 'ghi'}
+
+      const result = matchFilters(filters, event)
+
+      expect(result).toEqual(true)
+    })
+
+    it('should return true when event matches one or more filters and some have limit set', () => {
+      const filters = [
+        {ids: ['123'], limit: 1},
+        {kinds: [1], limit: 2},
+        {authors: ['abc'], limit: 3}
+      ]
+
+      const event = {id: '123', kind: 1, pubkey: 'abc', created_at: 150}
+
+      const result = matchFilters(filters, event)
+
+      expect(result).toEqual(true)
+    })
+
+    it('should return false when no filters match the event', () => {
+      const filters = [
+        {ids: ['123'], kinds: [1], authors: ['abc']},
+        {ids: ['456'], kinds: [2], authors: ['def']},
+        {ids: ['789'], kinds: [3], authors: ['ghi']}
+      ]
+
+      const event = {id: '100', kind: 4, pubkey: 'jkl'}
+
+      const result = matchFilters(filters, event)
+
+      expect(result).toEqual(false)
+    })
+
+    it('should return false when event matches none of the filters and some have limit set', () => {
+      const filters = [
+        {ids: ['123'], limit: 1},
+        {kinds: [1], limit: 2},
+        {authors: ['abc'], limit: 3}
+      ]
+      const event = {id: '456', kind: 2, pubkey: 'def', created_at: 200}
+
+      const result = matchFilters(filters, event)
+
+      expect(result).toEqual(false)
     })
   })
 })


### PR DESCRIPTION
added 13 test cases for filter.ts

matchFilter
      √ should return true when all filter conditions are met
      √ should return false when the event id is not in the filter
      √ should return false when the event kind is not in the filter
      √ should return false when the event author is not in the filter
      √ should return false when a tag is not present in the event
      √ should return false when a tag value is not present in the event
      √ should return true when filter has tags that is present in the event
      √ should return false when the event is before the filter since value
      √ should return false when the event is after the filter until value
    matchFilters
      √ should return true when at least one filter matches the event
      √ should return true when event matches one or more filters and some have limit set
      √ should return false when no filters match the event
      √ should return false when event matches none of the filters and some have limit set


Test Suites: 1 passed, 1 total
Tests:       13 passed, 13 total