### PR TITLE
validateEvent: use assertion function

### DIFF
--- a/event.ts
+++ b/event.ts
@@ -78,7 +78,7 @@ export function getEventHash(event: UnsignedEvent): string {
   return secp256k1.utils.bytesToHex(eventHash)
 }
 
-export function validateEvent(event: UnsignedEvent): boolean {
+export function validateEvent<T>(event: T): event is T & UnsignedEvent {
   if (typeof event !== 'object') return false
   if (typeof event.kind !== 'number') return false
   if (typeof event.content !== 'string') return false


### PR DESCRIPTION
Improves the return type of validateEvent so it can act as a guard. This allows passing `unknown` into it to get back an `UnsignedEvent`. If you pass a more fully-qualified type like `Event`, it'll return the more detailed type. This is a backwards-compatible change.