### PR TITLE
Reuse a connectionPromise for relay connect

### DIFF
--- a/pool.ts
+++ b/pool.ts
@@ -26,22 +26,16 @@ export class SimplePool {
 
   async ensureRelay(url: string): Promise<Relay> {
     const nm = normalizeURL(url)
-    const existing = this._conn[nm]
-    if (existing && existing.status === 1) return existing
 
-    if (existing) {
-      await existing.connect()
-      return existing
+    if (!this._conn[nm]) {
+      this._conn[nm] = relayInit(nm, {
+        getTimeout: this.getTimeout * 0.9,
+        listTimeout: this.getTimeout * 0.9
+      })
     }
 
-    const relay = relayInit(nm, {
-      getTimeout: this.getTimeout * 0.9,
-      listTimeout: this.getTimeout * 0.9
-    })
-    this._conn[nm] = relay
-
+    const relay = this._conn[nm]
     await relay.connect()
-
     return relay
   }
 

--- a/relay.ts
+++ b/relay.ts
@@ -83,8 +83,10 @@ export function relayInit(
     }
   } = {}
 
+  var connectionPromise: Promise<void> | undefined
   async function connectRelay(): Promise<void> {
-    return new Promise((resolve, reject) => {
+    if (connectionPromise) return connectionPromise
+    connectionPromise = new Promise((resolve, reject) => {
       try {
         ws = new WebSocket(url)
       } catch (err) {
@@ -96,10 +98,12 @@ export function relayInit(
         resolve()
       }
       ws.onerror = () => {
+        connectionPromise = undefined
         listeners.error.forEach(cb => cb())
         reject()
       }
       ws.onclose = async () => {
+        connectionPromise = undefined
         listeners.disconnect.forEach(cb => cb())
       }
 
@@ -185,6 +189,8 @@ export function relayInit(
         }
       }
     })
+
+    return connectionPromise
   }
 
   function connected() {


### PR DESCRIPTION
Fixes a race condition in `relay.connect` and `pool.ensureRelay`.

On boot if the client issued several early `REQ` I noticed:

* multiple websocket connections would be opened, and only one used.
* a few `REQ` would be delayed by a second (from `trySend` when ws connection is not ready)

By adding a single `connectionPromise`, multiple concurrent calls to `connect()` will all block on the same promise and won't open up multiple websocket connections.

So calling `pool.ensureRelay` at top of program will avoid hitting the 1s timeout.  Possibly the timeout could be removed but not 100% sure on that.
