### PR TITLE
fix: must be tag not ref.

### DIFF
--- a/references.ts
+++ b/references.ts
@@ -81,7 +81,7 @@ export function parseReferences(evt: Event): Reference[] {
         }
         case 'a': {
           try {
-            let [kind, pubkey, identifier] = ref[1].split(':')
+            let [kind, pubkey, identifier] = tag[1].split(':')
             references.push({
               text: ref[0],
               address: {


### PR DESCRIPTION
https://github.com/nostr-protocol/nips/blob/e219ec64701d89e6b2c3f3ca8fd426d0aefdcb9c/33.md?plain=1#L47

> The equivalent in `tags` to the `naddr` code is the tag `"a"`, comprised of `["a", "<kind>:<pubkey>:<d-identifier>", "<relay url>"]`.
