### PR TITLE
fix: mnemonic strength should be 256 bits.

### DIFF
--- a/nip06.ts
+++ b/nip06.ts
@@ -18,7 +18,7 @@ export function privateKeyFromSeedWords(
 }
 
 export function generateSeedWords(): string {
-  return generateMnemonic(wordlist)
+  return generateMnemonic(wordlist, 256)
 }
 
 export function validateWords(words: string): boolean {


### PR DESCRIPTION
`bip39.generateMnemonic(wordlist)` generates 128 bit strength key without `strength` option.
In my opinion, it should be 256 bit.

* https://github.com/paulmillr/scure-bip39/blob/dfadcd338cb0954e60627fccaa658671e5d33257/src/index.ts#L39
* https://github.com/v0l/snort/pull/435