### PR TITLE
scripts: add npm build, format and test scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,11 @@
     "client",
     "nostr"
   ],
+  "scripts": {
+    "build": "node build",
+    "format": "prettier --plugin-search-dir . --write .",
+    "test": "node build && jest"
+  },
   "devDependencies": {
     "@types/node": "^18.13.0",
     "@typescript-eslint/eslint-plugin": "^5.51.0",


### PR DESCRIPTION
in addition to the just tasks, this commit adds npm scripts back, for convenience.
    
example taks:
- npm test
- npm test filter.test.js
- npm run build
- npm run format
    
in yarn it should just work without 'run' i.e. 'yarn build'.