### PR TITLE
Fix validateEvent type checking

### DIFF
--- a/event.ts
+++ b/event.ts
@@ -78,8 +78,10 @@ export function getEventHash(event: UnsignedEvent): string {
   return secp256k1.utils.bytesToHex(eventHash)
 }
 
+const isRecord = (obj: unknown): obj is Record<string, unknown> => obj instanceof Object
+
 export function validateEvent<T>(event: T): event is T & UnsignedEvent {
-  if (typeof event !== 'object') return false
+  if (!isRecord(event)) return false
   if (typeof event.kind !== 'number') return false
   if (typeof event.content !== 'string') return false
   if (typeof event.created_at !== 'number') return false


### PR DESCRIPTION
Fixes the regression in type-checking caused by #168 

It does two things:

1. Prefers `event instanceof Object` instead of `typeof event === 'object'`. The second way allows `null` while the first way does not. That could result in a runtime error.
2. Adds an `isRecord` function to coerce the type of `event`, allowing us to read arbitrary properties off it fixing the type errors.