### PR TITLE
fix(nip05): allow dot in name

### DIFF
--- a/nip05.test.js
+++ b/nip05.test.js
@@ -17,4 +17,9 @@ test('fetch nip05 profiles', async () => {
     '32e1827635450ebb3c5a7d12c1f8e7b2b514439ac10a67eef3d9fd9c5c68e245'
   )
   expect(p2.relays).toEqual(['wss://relay.damus.io'])
+
+  let p3 = await nip05.queryProfile('channel.ninja@channel.ninja')
+  expect(p3.pubkey).toEqual(
+    '36e65b503eba8a6b698e724a59137603101166a1cddb45ddc704247fc8aa0fce'
+  )
 })

--- a/nip05.ts
+++ b/nip05.ts
@@ -36,7 +36,7 @@ export async function queryProfile(
     name = '_'
   }
 
-  if (!name.match(/^[A-Za-z0-9-_]+$/)) return null
+  if (!name.match(/^[A-Za-z0-9-_.]+$/)) return null
   if (!domain.includes('.')) return null
 
   let res


### PR DESCRIPTION
This PR allows the use of dots in the `<local-part>` in `queryProfile(fullname)`

As described in https://github.com/nostr-protocol/nips/blob/master/05.md the `<local-part>` should include a dot: `a-z0-9-_.`

