### PR TITLE
nip19: improve return type

### DIFF
--- a/nip19.ts
+++ b/nip19.ts
@@ -23,10 +23,15 @@ export type AddressPointer = {
   relays?: string[]
 }
 
-export function decode(nip19: string): {
-  type: string
-  data: ProfilePointer | EventPointer | AddressPointer | string
-} {
+export type DecodeResult =
+  | {type: 'nprofile'; data: ProfilePointer}
+  | {type: 'nevent'; data: EventPointer}
+  | {type: 'naddr'; data: AddressPointer}
+  | {type: 'nsec'; data: string}
+  | {type: 'npub'; data: string}
+  | {type: 'note'; data: string}
+
+export function decode(nip19: string): DecodeResult {
   let {prefix, words} = bech32.decode(nip19, Bech32MaxSize)
   let data = new Uint8Array(bech32.fromWords(words))
 


### PR DESCRIPTION
Makes the return type of `nip19.decode` a [discriminated union](https://knowledgehub.hashnode.dev/typescript-discriminated-unions-a-guide-to-understanding), allowing you to use a `switch` statement on `result.type` and then `result.data` will be automatically inferred.

Eg:

```ts
const result = decode('1234...')

switch (result.type) {
  case 'nprofile':
    result.data // ProfilePointer inferred
    break
  case 'npub':
    result.data // string inferred
    break
}
```