### PR TITLE
Add Unlicense

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,24 @@
+This is free and unencumbered software released into the public domain.
+
+Anyone is free to copy, modify, publish, use, compile, sell, or
+distribute this software, either in source code form or as a compiled
+binary, for any purpose, commercial or non-commercial, and by any
+means.
+
+In jurisdictions that recognize copyright laws, the author or authors
+of this software dedicate any and all copyright interest in the
+software to the public domain. We make this dedication for the benefit
+of the public at large and to the detriment of our heirs and
+successors. We intend this dedication to be an overt act of
+relinquishment in perpetuity of all present and future rights to this
+software under copyright law.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+OTHER DEALINGS IN THE SOFTWARE.
+
+For more information, please refer to <https://unlicense.org>

--- a/README.md
+++ b/README.md
@@ -325,4 +325,4 @@ Please consult the tests or [the source code](https://github.com/fiatjaf/nostr-t
 
 ## License
 
-Public domain.
+This is free and unencumbered software released into the public domain. By submitting patches to this project, you agree to dedicate any and all copyright interest in this software to the public domain.

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "import": "./lib/esm/nostr.mjs",
     "require": "./lib/nostr.cjs.js"
   },
-  "license": "Public domain",
+  "license": "Unlicense",
   "dependencies": {
     "@noble/hashes": "1.2.0",
     "@noble/secp256k1": "1.7.0",


### PR DESCRIPTION
Unlicense is a slightly more formal public domain dedication. Info here: https://unlicense.org/

Benefits include:

1. It's just a public domain dedication, as you already intend
2. A proper SPDX identifier in package.json so automated tools can detect the license
3. GitHub will prominently display the license
4. It includes additional clarifying language
5. It's shorter than CC0, which is more in the spirit of Nostr

Side-note that unless you're using a copyleft license like the GPL, you basically need a CLA to ensure the code will be forever free when you accept outside contributions. However this affects most of open source code, including most projects under MIT. So I'm going to mostly ignore that for now, but I added a statement to the README to sorta cover it:

> By submitting patches to this project, you agree to dedicate any and all copyright interest in this software to the public domain.