### PR TITLE
Rename signEvent to getSignature

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ let pk = getPublicKey(sk) // `pk` is a hex string
 import {
   validateEvent,
   verifySignature,
-  signEvent,
+  getSignature,
   getEventHash,
   getPublicKey
 } from 'nostr-tools'
@@ -41,7 +41,7 @@ let event = {
 }
 
 event.id = getEventHash(event)
-event.sig = signEvent(event, privateKey)
+event.sig = getSignature(event, privateKey)
 
 let ok = validateEvent(event)
 let veryOk = verifySignature(event)
@@ -55,7 +55,7 @@ import {
   generatePrivateKey,
   getPublicKey,
   getEventHash,
-  signEvent
+  getSignature
 } from 'nostr-tools'
 
 const relay = relayInit('wss://relay.example.com')
@@ -104,7 +104,7 @@ let event = {
   content: 'hello world'
 }
 event.id = getEventHash(event)
-event.sig = signEvent(event, sk)
+event.sig = getSignature(event, sk)
 
 let pub = relay.publish(event)
 pub.on('ok', () => {

--- a/event.test.js
+++ b/event.test.js
@@ -5,7 +5,7 @@ const {
   getEventHash,
   validateEvent,
   verifySignature,
-  signEvent,
+  getSignature,
   getPublicKey,
   Kind
 } = require('./lib/nostr.cjs')
@@ -281,8 +281,8 @@ describe('Event', () => {
     })
   })
 
-  describe('signEvent', () => {
-    it('should sign an event object', () => {
+  describe('getSignature', () => {
+    it('should produce the correct signature for an event object', () => {
       const privateKey =
         'd217c1ff2f8a65c3e3a1740db3b9f58b8c848bb45e26d00ed4714e4a0f4ceecf'
       const publicKey = getPublicKey(privateKey)
@@ -295,7 +295,7 @@ describe('Event', () => {
         pubkey: publicKey
       }
 
-      const sig = signEvent(unsignedEvent, privateKey)
+      const sig = getSignature(unsignedEvent, privateKey)
 
       // verify the signature
       const isValid = verifySignature({
@@ -324,7 +324,7 @@ describe('Event', () => {
         pubkey: publicKey
       }
 
-      const sig = signEvent(unsignedEvent, wrongPrivateKey)
+      const sig = getSignature(unsignedEvent, wrongPrivateKey)
 
       // verify the signature
       const isValid = verifySignature({

--- a/event.ts
+++ b/event.ts
@@ -111,6 +111,14 @@ export function verifySignature(event: Event): boolean {
   )
 }
 
+/** @deprecated Use `getSignature` instead. */
+export function signEvent(event: UnsignedEvent, key: string): string {
+  console.warn(
+    'nostr-tools: `signEvent` is deprecated and will be removed or changed in the future. Please use `getSignature` instead.'
+  )
+  return getSignature(event, key)
+}
+
 /** Calculate the signature for an event. */
 export function getSignature(event: UnsignedEvent, key: string): string {
   return secp256k1.utils.bytesToHex(

--- a/event.ts
+++ b/event.ts
@@ -58,7 +58,7 @@ export function finishEvent(t: EventTemplate, privateKey: string): Event {
   let event = t as Event
   event.pubkey = getPublicKey(privateKey)
   event.id = getEventHash(event)
-  event.sig = signEvent(event, privateKey)
+  event.sig = getSignature(event, privateKey)
   return event
 }
 
@@ -111,7 +111,8 @@ export function verifySignature(event: Event): boolean {
   )
 }
 
-export function signEvent(event: UnsignedEvent, key: string): string {
+/** Calculate the signature for an event. */
+export function getSignature(event: UnsignedEvent, key: string): string {
   return secp256k1.utils.bytesToHex(
     secp256k1.schnorr.signSync(getEventHash(event), key)
   )

--- a/pool.test.js
+++ b/pool.test.js
@@ -6,7 +6,7 @@ const {
   generatePrivateKey,
   getPublicKey,
   getEventHash,
-  signEvent
+  getSignature
 } = require('./lib/nostr.cjs')
 
 let pool = new SimplePool()
@@ -50,7 +50,7 @@ test('removing duplicates when querying', async () => {
     tags: []
   }
   event.id = getEventHash(event)
-  event.sig = signEvent(event, priv)
+  event.sig = getSignature(event, priv)
 
   pool.publish(relays, event)
 
@@ -84,7 +84,7 @@ test('same with double querying', async () => {
     tags: []
   }
   event.id = getEventHash(event)
-  event.sig = signEvent(event, priv)
+  event.sig = getSignature(event, priv)
 
   pool.publish(relays, event)
 

--- a/relay.test.js
+++ b/relay.test.js
@@ -6,7 +6,7 @@ const {
   generatePrivateKey,
   getPublicKey,
   getEventHash,
-  signEvent
+  getSignature
 } = require('./lib/nostr.cjs')
 
 let relay = relayInit('wss://relay.damus.io/')
@@ -124,7 +124,7 @@ test('listening (twice) and publishing', async () => {
     content: 'nostr-tools test suite'
   }
   event.id = getEventHash(event)
-  event.sig = signEvent(event, sk)
+  event.sig = getSignature(event, sk)
 
   relay.publish(event)
   return expect(


### PR DESCRIPTION
The existing `signEvent` function is named incorrectly. It should be called `getSignature`, which matches its partner function `getEventHash`. This is because it returns a _string_ instead of a signed event. Even NIP-07's `window.nostr.signEvent` function is correct, returning the signed event, but the one in this repo isn't.

This is a breaking change, but I think it's needed. The name of this function interferes with actual `signEvent` implementations.