### PR TITLE
fix(nip04): crypto.subtle is undefined and support node v16

### DIFF
--- a/nip04.ts
+++ b/nip04.ts
@@ -1,11 +1,11 @@
 import {randomBytes} from '@noble/hashes/utils'
 import * as secp256k1 from '@noble/secp256k1'
 import {base64} from '@scure/base'
-import crypto from 'crypto'
 
 import {utf8Decoder, utf8Encoder} from './utils'
 
-if (!crypto.subtle) {
+// @ts-ignore
+if (typeof(crypto) !== 'undefined' && !crypto.subtle  && crypto.webcrypto) {
   // @ts-ignore
   crypto.subtle = crypto.webcrypto.subtle
 }

--- a/nip04.ts
+++ b/nip04.ts
@@ -1,8 +1,14 @@
 import {randomBytes} from '@noble/hashes/utils'
 import * as secp256k1 from '@noble/secp256k1'
 import {base64} from '@scure/base'
+import crypto from 'crypto'
 
 import {utf8Decoder, utf8Encoder} from './utils'
+
+if (!crypto.subtle) {
+  // @ts-ignore
+  crypto.subtle = crypto.webcrypto.subtle
+}
 
 export async function encrypt(
   privkey: string,


### PR DESCRIPTION
This PR fix `crypto.subtle` is `undefined` in Node.js v16 and earlier versions. It fixes the issue by adding the following code in the `nip04.ts` file:

```javascript
// @ts-ignore
if (typeof(crypto) !== 'undefined' && !crypto.subtle  && crypto.webcrypto) {
  // @ts-ignore
  crypto.subtle = crypto.webcrypto.subtle
}
```

From [node doc: crypto.subtle](https://nodejs.org/dist/latest-v18.x/docs/api/crypto.html#cryptosubtle) , `crypto.subtle` added in Node.js v17.4 as alias for `crypto.webcrypto.subtle`。So `crypto.subtle` is `undefined` in Node.js v16 and v15。

The code sets `crypto.subtle` to `crypto.webcrypto.subtle` if `crypto.subtle` is `undefined`, which enables support for older versions of Node.js.

Tested the changes by running the code in Node.js v16.19 and verified that crypto.subtle is now defined.