### PR TITLE
Make Event a generic type accepting Kind

### DIFF
--- a/event.ts
+++ b/event.ts
@@ -29,23 +29,23 @@ export enum Kind {
   Article = 30023
 }
 
-export type EventTemplate = {
-  kind: Kind
+export type EventTemplate<K extends number = Kind> = {
+  kind: K
   tags: string[][]
   content: string
   created_at: number
 }
 
-export type UnsignedEvent = EventTemplate & {
+export type UnsignedEvent<K extends number = Kind> = EventTemplate<K> & {
   pubkey: string
 }
 
-export type Event = UnsignedEvent & {
+export type Event<K extends number = Kind> = UnsignedEvent<K> & {
   id: string
   sig: string
 }
 
-export function getBlankEvent(): EventTemplate {
+export function getBlankEvent(): EventTemplate<number> {
   return {
     kind: 255,
     content: '',


### PR DESCRIPTION
Allows using types like `Event<3>` and `SignedEvent<1>`, etc.

Using plain old `Event` will still work, and it preserves the current behavior. With no arguments it will match only the known `Kind`s, but you can also use `Event<number>` to match any kind.

As a result you can can do awesome stuff like this, where your functions guard against particular kinds of events: https://gitlab.com/soapbox-pub/mostr/-/blob/c67064aee5ade5e01597c6d23e22e53c628ef0e2/src/activitypub/transmute.ts#L184

I've been using this pattern in all my Nostr projects. It doesn't have the full discriminated-union behavior I wish it did in switch statements, but for what's currently possible in TypeScript, it's a huge improvement.

This is a backwards-compatible change.