### PR TITLE
feat: getBlankEvent accept a kind

### DIFF
--- a/event.test.js
+++ b/event.test.js
@@ -20,6 +20,15 @@ describe('Event', () => {
         created_at: 0
       })
     })
+
+    it('should return a blank event object with defined kind', () => {
+      expect(getBlankEvent(Kind.Text)).toEqual({
+        kind: 1,
+        content: '',
+        tags: [],
+        created_at: 0
+      })
+    })
   })
 
   describe('finishEvent', () => {

--- a/event.ts
+++ b/event.ts
@@ -6,6 +6,7 @@ import {getPublicKey} from './keys'
 
 /* eslint-disable no-unused-vars */
 export enum Kind {
+  UndefinedKindNumber = 255,
   Metadata = 0,
   Text = 1,
   RecommendRelay = 2,
@@ -45,9 +46,9 @@ export type Event<K extends number = Kind> = UnsignedEvent<K> & {
   sig: string
 }
 
-export function getBlankEvent(): EventTemplate<number> {
+export function getBlankEvent<K extends Kind = Kind.UndefinedKindNumber>(kind?: K): EventTemplate<K> {
   return {
-    kind: 255,
+    kind: kind || ( Kind.UndefinedKindNumber as K),
     content: '',
     tags: [],
     created_at: 0


### PR DESCRIPTION
Allow `getBlankEvent` accept a kind number and return `type` base the param passed.

There are the `type` of `e` and the `type` of `e.kind` which vscode detected.

<img width="687" alt="2023-05-02 02 49 40" src="https://user-images.githubusercontent.com/19855678/235509969-ec7fa53d-f08e-4609-ab4f-30ced641c15a.png">

<img width="985" alt="2023-05-02 02 53 46" src="https://user-images.githubusercontent.com/19855678/235510616-47395f47-f288-4b6c-8b30-528b07a8523f.png">

It also accept a `number` of `Kind`, in this way `type` of `e.kind` is a number `1`.

<img width="562" alt="截屏2023-05-02 02 58 47" src="https://user-images.githubusercontent.com/19855678/235511442-38f72cdd-13be-4c5a-ba87-3d624f5ab9f0.png">

