### PR TITLE
Make Filter a generic type accepting Kind

### DIFF
--- a/filter.ts
+++ b/filter.ts
@@ -1,8 +1,8 @@
-import {Event} from './event'
+import {Event, type Kind} from './event'
 
-export type Filter = {
+export type Filter<K extends number = Kind> = {
   ids?: string[]
-  kinds?: number[]
+  kinds?: K[]
   authors?: string[]
   since?: number
   until?: number


### PR DESCRIPTION
Gives Filter a similar treatment as #199 

This allows you to write code like this:

```ts
/** Fetches events from relays according to the filter. */
function getFilter<K extends number>(filter: Filter<K>, opts: GetFilterOpts = {}): Promise<SignedEvent<K>[]> {
  // TODO: actually fetch the events
  return events;
}

// `events` is inferred as `SignedEvent<1>[]`
const events = await getFilter({ authors: [pubkey], kinds: [1] });

// `events` is inferred as `SignedEvent<1 | 6 | 7>[]`
const events = await getFilter({ authors: [pubkey], kinds: [1, 6, 7] });
```