### PR TITLE
Fix subtle inconsistency with NIP-04 in the decryption example

### DIFF
--- a/README.md
+++ b/README.md
@@ -266,7 +266,7 @@ sendEvent(event)
 
 // on the receiver side
 sub.on('event', event => {
-  let sender = event.tags.find(([k, v]) => k === 'p' && v && v !== '')[1]
+  let sender = event.pubkey
   pk1 === sender
   let plaintext = await nip04.decrypt(sk2, pk1, event.content)
 })


### PR DESCRIPTION
Sender's pubkey was searched for in the `p` tag, where receiver's pubkey is found; use `event.pubkey` instead.