### PR TITLE
Move BECH32_REGEX to nip19.ts

### DIFF
--- a/nip19.ts
+++ b/nip19.ts
@@ -5,6 +5,13 @@ import {utf8Decoder, utf8Encoder} from './utils'
 
 const Bech32MaxSize = 5000
 
+/**
+ * Bech32 regex.
+ * @see https://github.com/bitcoin/bips/blob/master/bip-0173.mediawiki#bech32
+ */
+export const BECH32_REGEX =
+  /[\x21-\x7E]{1,83}1[023456789acdefghjklmnpqrstuvwxyz]{6,}/
+
 export type ProfilePointer = {
   pubkey: string // hex
   relays?: string[]

--- a/nip21.ts
+++ b/nip21.ts
@@ -1,15 +1,8 @@
 import * as nip19 from './nip19'
 import * as nip21 from './nip21'
 
-/**
- * Bech32 regex.
- * @see https://github.com/bitcoin/bips/blob/master/bip-0173.mediawiki#bech32
- */
-export const BECH32_REGEX =
-  /[\x21-\x7E]{1,83}1[023456789acdefghjklmnpqrstuvwxyz]{6,}/
-
 /** Nostr URI regex, eg `nostr:npub1...` */
-export const NOSTR_URI_REGEX = new RegExp(`nostr:(${BECH32_REGEX.source})`)
+export const NOSTR_URI_REGEX = new RegExp(`nostr:(${nip19.BECH32_REGEX.source})`)
 
 /** Test whether the value is a Nostr URI. */
 export function test(value: unknown): value is `nostr:${string}` {


### PR DESCRIPTION
This is technically a breaking change since `BECH32_REGEX` is exported, but I doubt anyone is depending on it yet. I used it in a project and it bothered me that it was in nip21 when I wasn't doing stuff related to content parsing.