### PR TITLE
Replace array list queue with a linked list one 

### DIFF
--- a/utils.test.ts
+++ b/utils.test.ts
@@ -1,5 +1,6 @@
 import {buildEvent} from './test-helpers.ts'
 import {
+  MessageQueue,
   insertEventIntoAscendingList,
   insertEventIntoDescendingList,
 } from './utils.ts'
@@ -189,5 +190,50 @@ describe('inserting into a asc sorted list of events', () => {
       created_at: 30
     }))
     expect(list1).toHaveLength(3)
+  })
+})
+
+describe('enque a message into MessageQueue', () => {
+  test('enque into an empty queue', () => {
+    const queue = new MessageQueue()
+    queue.enqueue('node1')
+    expect(queue.first!.value).toBe('node1')
+  })
+  test('enque into a non-empty queue', () => {
+    const queue = new MessageQueue()
+    queue.enqueue('node1')
+    queue.enqueue('node3')
+    queue.enqueue('node2')
+    expect(queue.first!.value).toBe('node1')
+    expect(queue.last!.value).toBe('node2')
+    expect(queue.size).toBe(3)
+  })
+  test('dequeue from an empty queue', () => {
+    const queue = new MessageQueue()
+    const item1 = queue.dequeue()
+    expect(item1).toBe(null)
+    expect(queue.size).toBe(0)
+  })
+  test('dequeue from a non-empty queue', () => {
+    const queue = new MessageQueue()
+    queue.enqueue('node1')
+    queue.enqueue('node3')
+    queue.enqueue('node2')
+    const item1 = queue.dequeue()
+    expect(item1).toBe('node1')
+    const item2 = queue.dequeue()
+    expect(item2).toBe('node3')
+  })
+  test('dequeue more than in queue', () => {
+    const queue = new MessageQueue()
+    queue.enqueue('node1')
+    queue.enqueue('node3')
+    const item1 = queue.dequeue()
+    expect(item1).toBe('node1')
+    const item2 = queue.dequeue()
+    expect(item2).toBe('node3')
+    expect(queue.size).toBe(0)
+    const item3 = queue.dequeue()
+    expect(item3).toBe(null)
   })
 })

--- a/utils.ts
+++ b/utils.ts
@@ -111,77 +111,77 @@ export function insertEventIntoAscendingList(
 }
 
 export class MessageNode {
-  private _value: string;
-  private _next: MessageNode|null;
+  private _value: string
+  private _next: MessageNode | null
 
   public get value(): string {
-    return this._value;
+    return this._value
   }
   public set value(message: string) {
-    this._value = message;
+    this._value = message
   }
-  public get next(): MessageNode|null {
-    return this._next;
+  public get next(): MessageNode | null {
+    return this._next
   }
-  public set next(node: MessageNode|null) {
-    this._next = node;
+  public set next(node: MessageNode | null) {
+    this._next = node
   }
 
   constructor(message: string) {
-    this._value = message;
-    this._next = null;
+    this._value = message
+    this._next = null
   }
 }
 
 export class MessageQueue {
-  private _first: MessageNode|null;
-  private _last: MessageNode|null;
+  private _first: MessageNode | null
+  private _last: MessageNode | null
 
-  public get first(): MessageNode|null {
-    return this._first;
+  public get first(): MessageNode | null {
+    return this._first
   }
-  public set first(messageNode: MessageNode|null) {
-    this._first = messageNode;
+  public set first(messageNode: MessageNode | null) {
+    this._first = messageNode
   }
-  public get last(): MessageNode|null {
-    return this._last;
+  public get last(): MessageNode | null {
+    return this._last
   }
-  public set last(messageNode: MessageNode|null) {
-    this._last = messageNode;
+  public set last(messageNode: MessageNode | null) {
+    this._last = messageNode
   }
-  private _size: number;
+  private _size: number
   public get size(): number {
-    return this._size;
+    return this._size
   }
   public set size(v: number) {
-    this._size = v;
+    this._size = v
   }
 
   constructor() {
-    this._first = null;
-    this._last = null;
-    this._size = 0;
+    this._first = null
+    this._last = null
+    this._size = 0
   }
   enqueue(message: string): boolean {
-    const newNode = new MessageNode(message);
-    if (this._size == 0 || !this._last) {
-      this._first = newNode;
-      this._last = newNode;
+    const newNode = new MessageNode(message)
+    if (this._size === 0 || !this._last) {
+      this._first = newNode
+      this._last = newNode
     } else {
-        this._last.next = newNode;
-        this._last = newNode;
+      this._last.next = newNode
+      this._last = newNode
     }
-    this._size++;
-    return true;
+    this._size++
+    return true
   }
-  dequeue(): string|null {
-     if (this._size == 0 || !this._first) return null;
+  dequeue(): string | null {
+    if (this._size === 0 || !this._first) return null
 
-     let prev = this._first;
-     this._first = prev.next;
-     prev.next = null;
+    let prev = this._first
+    this._first = prev.next
+    prev.next = null
 
-     this._size--;
-     return prev.value;
-   }
+    this._size--
+    return prev.value
+  }
 }

--- a/utils.ts
+++ b/utils.ts
@@ -109,3 +109,79 @@ export function insertEventIntoAscendingList(
 
   return sortedArray
 }
+
+export class MessageNode {
+  private _value: string;
+  private _next: MessageNode|null;
+
+  public get value(): string {
+    return this._value;
+  }
+  public set value(message: string) {
+    this._value = message;
+  }
+  public get next(): MessageNode|null {
+    return this._next;
+  }
+  public set next(node: MessageNode|null) {
+    this._next = node;
+  }
+
+  constructor(message: string) {
+    this._value = message;
+    this._next = null;
+  }
+}
+
+export class MessageQueue {
+  private _first: MessageNode|null;
+  private _last: MessageNode|null;
+
+  public get first(): MessageNode|null {
+    return this._first;
+  }
+  public set first(messageNode: MessageNode|null) {
+    this._first = messageNode;
+  }
+  public get last(): MessageNode|null {
+    return this._last;
+  }
+  public set last(messageNode: MessageNode|null) {
+    this._last = messageNode;
+  }
+  private _size: number;
+  public get size(): number {
+    return this._size;
+  }
+  public set size(v: number) {
+    this._size = v;
+  }
+
+  constructor() {
+    this._first = null;
+    this._last = null;
+    this._size = 0;
+  }
+  enqueue(message: string): boolean {
+    const newNode = new MessageNode(message);
+    if (this._size == 0 || !this._last) {
+      this._first = newNode;
+      this._last = newNode;
+    } else {
+        this._last.next = newNode;
+        this._last = newNode;
+    }
+    this._size++;
+    return true;
+  }
+  dequeue(): string|null {
+     if (this._size == 0 || !this._first) return null;
+
+     let prev = this._first;
+     this._first = prev.next;
+     prev.next = null;
+
+     this._size--;
+     return prev.value;
+   }
+}


### PR DESCRIPTION
The relay object uses incomingMessageQueue as a way to keep a fifo queue of messages incoming from open ws connections. This array is a fundamental part of the whole library and its .unshift() gets called a lot.

Because JavaScript Arrays are ArrayLists, their .unshift() method is work intensive (O(n)). When called every single remaining item in it needs to get a new index assigned, which makes them a suboptimal choice for queues.

I believe we should replace the standard ArrayList with data structure more suited for this task. I have added a MessageQueue class to the ulitities that implements a LinkedList, which exposes enqueue and dequeue methods(both O(1)).

Before I spent more time on this I wanted to get the maintainers input on this. Is there maybe something that I am missing that made the standard array the better choice?