### PR TITLE
NIP-26: Allow multiple kinds in createDelegation

### DIFF
--- a/nip26.test.ts
+++ b/nip26.test.ts
@@ -103,3 +103,13 @@ test('create and verify delegation', async () => {
   })
   expect(getDelegator(event)).toEqual(pk1)
 })
+
+test('can create delegation with multiple kinds', async () => {
+  let sk1 = generatePrivateKey()
+  let sk2 = generatePrivateKey()
+  let pk2 = getPublicKey(sk2)
+  let delegation = createDelegation(sk1, {pubkey: pk2, kind: [1, 4]})
+
+  expect(delegation.cond).toContain('kind=1')
+  expect(delegation.cond).toContain('kind=4')
+})

--- a/nip26.ts
+++ b/nip26.ts
@@ -9,7 +9,7 @@ import type {Event} from './event.ts'
 
 export type Parameters = {
   pubkey: string // the key to whom the delegation will be given
-  kind?: number
+  kind?: number | Array<number>
   until?: number // delegation will only be valid until this date
   since?: number // delegation will be valid from this date on
 }
@@ -26,7 +26,14 @@ export function createDelegation(
   parameters: Parameters
 ): Delegation {
   let conditions = []
-  if ((parameters.kind || -1) >= 0) conditions.push(`kind=${parameters.kind}`)
+  let kinds = Array.isArray(parameters.kind) ? parameters.kind : [parameters.kind]
+
+  kinds.forEach(kind => {
+    if ((kind || -1) >= 0) {
+      conditions.push(`kind=${kind}`)
+    }
+  })
+
   if (parameters.until) conditions.push(`created_at<${parameters.until}`)
   if (parameters.since) conditions.push(`created_at>${parameters.since}`)
   let cond = conditions.join('&')


### PR DESCRIPTION
The NIP-26 doc says multiple kinds are valid in the cond. This modifies the createDelegation method to allow putting an array of numbers for the kind param.