### PR TITLE
Fix nip27.matchAll crash on invalid nip19

### DIFF
--- a/nip27.test.ts
+++ b/nip27.test.ts
@@ -29,6 +29,25 @@ test('matchAll', () => {
   ])
 })
 
+test('matchAll with an invalid nip19', () => {
+  const result = matchAll(
+    'Hello npub129tvj896hqqkljerxkccpj9flshwnw999v9uwn9lfmwlj8vnzwgq9y5llnpub1rujdpkd8mwezrvpqd2rx2zphfaztqrtsfg6w3vdnlj!\n\nnostr:note1gmtnz6q2m55epmlpe3semjdcq987av3jvx4emmjsa8g3s9x7tg4sclreky'
+  )
+
+  expect([...result]).toEqual([
+    {
+      decoded: {
+        data: '46d731680add2990efe1cc619dc9b8014feeb23261ab9dee50e9d11814de5a2b',
+        type: 'note'
+      },
+      end: 187,
+      start: 118,
+      uri: 'nostr:note1gmtnz6q2m55epmlpe3semjdcq987av3jvx4emmjsa8g3s9x7tg4sclreky',
+      value: 'note1gmtnz6q2m55epmlpe3semjdcq987av3jvx4emmjsa8g3s9x7tg4sclreky'
+    }
+  ])
+})
+
 test('replaceAll', () => {
   const content =
     'Hello nostr:npub108pv4cg5ag52nq082kd5leu9ffrn2gdg6g4xdwatn73y36uzplmq9uyev6!\n\nnostr:note1gmtnz6q2m55epmlpe3semjdcq987av3jvx4emmjsa8g3s9x7tg4sclreky'

--- a/nip27.ts
+++ b/nip27.ts
@@ -2,8 +2,7 @@ import {decode} from './nip19.ts'
 import {NOSTR_URI_REGEX, type NostrURI} from './nip21.ts'
 
 /** Regex to find NIP-21 URIs inside event content. */
-export const regex = () =>
-  new RegExp(`\\b${NOSTR_URI_REGEX.source}\\b`, 'g')
+export const regex = () => new RegExp(`\\b${NOSTR_URI_REGEX.source}\\b`, 'g')
 
 /** Match result for a Nostr URI in event content. */
 export interface NostrURIMatch extends NostrURI {
@@ -14,18 +13,22 @@ export interface NostrURIMatch extends NostrURI {
 }
 
 /** Find and decode all NIP-21 URIs. */
-export function * matchAll(content: string): Iterable<NostrURIMatch> {
+export function* matchAll(content: string): Iterable<NostrURIMatch> {
   const matches = content.matchAll(regex())
 
   for (const match of matches) {
-    const [uri, value] = match
+    try {
+      const [uri, value] = match
 
-    yield {
-      uri: uri as `nostr:${string}`,
-      value,
-      decoded: decode(value),
-      start: match.index!,
-      end: match.index! + uri.length
+      yield {
+        uri: uri as `nostr:${string}`,
+        value,
+        decoded: decode(value),
+        start: match.index!,
+        end: match.index! + uri.length
+      }
+    } catch (_e) {
+      // do nothing
     }
   }
 }


### PR DESCRIPTION
I received this event containing an invalid nip19: https://www.nostr.guru/e/bd107ef2033ff82a42e5a1377020771253d795568a6db0e2b53ad53cb35d73d7

It crashed my web server, which uses the `nip27.matchAll` function.

I wrote that function. I thought a try-catch wasn't needed since we do a regex match first, but this nip19 matches the regex and still crashes because it's invalid (I think). So now we add a try-catch.

I'm not sure if it should crash or not, or what this nip19 is trying to represent. But this is what caused it:

```
npub129tvj896hqqkljerxkccpj9flshwnw999v9uwn9lfmwlj8vnzwgq9y5llnpub1rujdpkd8mwezrvpqd2rx2zphfaztqrtsfg6w3vdnljdghs2q8qrqtt9u686
```