### PR TITLE
nip19: use template literal types

### DIFF
--- a/nip19.ts
+++ b/nip19.ts
@@ -30,22 +30,26 @@ export type AddressPointer = {
   relays?: string[]
 }
 
-export type DecodeResult =
-  | {type: 'nprofile'; data: ProfilePointer}
-  | {type: 'nrelay'; data: string}
-  | {type: 'nevent'; data: EventPointer}
-  | {type: 'naddr'; data: AddressPointer}
-  | {type: 'nsec'; data: string}
-  | {type: 'npub'; data: string}
-  | {type: 'note'; data: string}
+type Prefixes = {
+  nprofile: ProfilePointer
+  nrelay: string
+  nevent: EventPointer
+  naddr: AddressPointer
+  nsec: string
+  npub: string
+  note: string
+}
 
-export function decode(nip19: `nprofile1${string}`): {type: 'nprofile'; data: ProfilePointer}
-export function decode(nip19: `nrelay1${string}`): {type: 'nrelay'; data: string}
-export function decode(nip19: `nevent1${string}`): {type: 'nevent'; data: EventPointer}
-export function decode(nip19: `naddr1${string}`): {type: 'naddr'; data: AddressPointer}
-export function decode(nip19: `nsec1${string}`): {type: 'nsec'; data: string}
-export function decode(nip19: `npub1${string}`): {type: 'npub'; data: string}
-export function decode(nip19: `note1${string}`): {type: 'note'; data: string}
+type DecodeValue<Prefix extends keyof Prefixes> = {
+  type: Prefix
+  data: Prefixes[Prefix]
+}
+
+export type DecodeResult = {
+  [P in keyof Prefixes]: DecodeValue<P>
+}[keyof Prefixes]
+
+export function decode<Prefix extends keyof Prefixes>(nip19: `${Prefix}1${string}`): DecodeValue<Prefix>
 export function decode(nip19: string): DecodeResult
 export function decode(nip19: string): DecodeResult {
   let {prefix, words} = bech32.decode(nip19, Bech32MaxSize)


### PR DESCRIPTION
```ts
const npub = nip19.npubEncode('79c2cae114ea28a981e7559b4fe7854a473521a8d22a66bbab9fa248eb820ff6')
const decoded = nip19.decode(npub) // type is `{type: 'npub'; data: string}` !!
```

Takes advantage of [template literal types](https://www.typescriptlang.org/docs/handbook/2/template-literal-types.html) so that if the specific nip19 type is already known, decoding it will return the correct type without needing to check it.


I think it's a good idea for nip19 template literals to be a thing, because then you could guard functions like:

```ts
// only gets pubkey from npub and nsec

function getPubkey(value: `npub1${string}` | `nsec1${string}`): string {
  return result.data // guaranteed to be a string
}
```

I'm using it for configuration in Ditto:

```ts
const Conf = {
  get nsec() {
    const _nsec = Deno.env.get('DITTO_NSEC');
    if (!_nsec?.startsWith('nsec1')) {
      throw new Error('The DITTO_NSEC environment variable is not set. Please generate a secret key for the server.');
    }
    return _nsec as `nsec1${string}`; // guaranteeing nsec
  }
}

// Now the decoded type is already known
const seckey: string = nip19.decode(Conf.nsec).data;
```