### PR TITLE
Add an option to disable `seenOn`

### DIFF
--- a/pool.test.ts
+++ b/pool.test.ts
@@ -121,3 +121,20 @@ test('list()', async () => {
     .reduce((acc, n) => acc.concat(n), [])
   expect(relaysForAllEvents.length).toBeGreaterThanOrEqual(events.length)
 })
+
+test('seenOnEnabled: false', async () => {
+  const poolWithoutSeenOn = new SimplePool({seenOnEnabled: false})
+
+  const event = await poolWithoutSeenOn.get(relays, {
+    ids: ['d7dd5eb3ab747e16f8d0212d53032ea2a7cadef53837e5a6c66d42849fcb9027']
+  })
+
+  expect(event).toHaveProperty(
+    'id',
+    'd7dd5eb3ab747e16f8d0212d53032ea2a7cadef53837e5a6c66d42849fcb9027'
+  )
+
+  const relaysForEvent = poolWithoutSeenOn.seenOn(event!.id)
+
+  expect(relaysForEvent).toHaveLength(0)
+})

--- a/pool.ts
+++ b/pool.ts
@@ -15,11 +15,13 @@ export class SimplePool {
 
   private eoseSubTimeout: number
   private getTimeout: number
+  private seenOnEnabled: boolean = true
 
-  constructor(options: {eoseSubTimeout?: number; getTimeout?: number} = {}) {
+  constructor(options: {eoseSubTimeout?: number; getTimeout?: number; seenOnEnabled?: boolean} = {}) {
     this._conn = {}
     this.eoseSubTimeout = options.eoseSubTimeout || 3400
     this.getTimeout = options.getTimeout || 3400
+    this.seenOnEnabled = options.seenOnEnabled !== false
   }
 
   close(relays: string[]): void {
@@ -51,9 +53,11 @@ export class SimplePool {
       if (opts?.alreadyHaveEvent?.(id, url)) {
         return true
       }
-      let set = this._seenOn[id] || new Set()
-      set.add(url)
-      this._seenOn[id] = set
+      if (this.seenOnEnabled) {
+        let set = this._seenOn[id] || new Set()
+        set.add(url)
+        this._seenOn[id] = set
+      }
       return _knownIds.has(id)
     }
 


### PR DESCRIPTION
`_seenOn` map grows indefinitely, if you do not intend on using `seenOn`, you can disable it to save memory and improve performance.