### PR TITLE
Update package.json to upgrade scure/bip39

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,10 +19,10 @@
   },
   "license": "Unlicense",
   "dependencies": {
-    "@noble/curves": "1.0.0",
-    "@noble/hashes": "1.3.0",
+    "@noble/curves": "1.1.0",
+    "@noble/hashes": "1.3.1",
     "@scure/base": "1.1.1",
-    "@scure/bip32": "1.3.0",
+    "@scure/bip32": "1.3.1",
     "@scure/bip39": "1.2.1"
   },
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "@noble/hashes": "1.3.0",
     "@scure/base": "1.1.1",
     "@scure/bip32": "1.3.0",
-    "@scure/bip39": "1.2.0"
+    "@scure/bip39": "1.2.1"
   },
   "keywords": [
     "decentralization",


### PR DESCRIPTION
solves problem of "scure/bip39 1.2.0 causing problem of "Can't resolve '@scure/bip39/wordlists/english' ... because it was resolved as fully specified "

Fixes #253 