### PR TITLE
fix breaking change

### DIFF
--- a/nip06.ts
+++ b/nip06.ts
@@ -1,5 +1,5 @@
 import {bytesToHex} from '@noble/hashes/utils'
-import {wordlist} from '@scure/bip39/wordlists/english'
+import {wordlist} from '@scure/bip39/wordlists/english.js'
 import {
   generateMnemonic,
   mnemonicToSeedSync,


### PR DESCRIPTION
Fixes this issue which has been driving me crazy

happens in react, nextjs and svelte using the latest build packs.

React Error: (webpack)
(probably because the origin is strict EcmaScript Module, e. g. a module with javascript mimetype, a '*.mjs' file, or a '*.js' file where the package.json contains '"type": "module"').
The extension in the request is mandatory for it to be fully specified.
Add the extension to the request.

Svelte Error (vite)

![image](https://github.com/nbd-wtf/nostr-tools/assets/111649294/c6a9b295-deaf-487d-8ab2-5cd61760c5ba)
