### PR TITLE
Add WebSocket polyfill for Node.js

### DIFF
--- a/relay.ts
+++ b/relay.ts
@@ -1,4 +1,5 @@
 /* global WebSocket */
+import 'websocket-polyfill'
 
 import {verifySignature, validateEvent, type Event} from './event.ts'
 import {matchFilters, type Filter} from './filter.ts'


### PR DESCRIPTION
I am seeing crashes when running the README examples on `node` (v18.12.1).

```
/Users/zeevo/Projects/nostr/node_modules/nostr-tools/lib/nostr.cjs.js:473
        ws = new WebSocket(url);
        ^

ReferenceError: WebSocket is not defined
    at /Users/zeevo/Projects/nostr/node_modules/nostr-tools/lib/nostr.cjs.js:473:9
    at new Promise (<anonymous>)
    at connectRelay (/Users/zeevo/Projects/nostr/node_modules/nostr-tools/lib/nostr.cjs.js:471:25)
    at Object.connect (/Users/zeevo/Projects/nostr/node_modules/nostr-tools/lib/nostr.cjs.js:579:11)
    at /Users/zeevo/Projects/nostr/src/sub.js:22:17
    at Generator.next (<anonymous>)
    at /Users/zeevo/Projects/nostr/src/sub.js:8:71
    at new Promise (<anonymous>)
    at __awaiter (/Users/zeevo/Projects/nostr/src/sub.js:4:12)
    at /Users/zeevo/Projects/nostr/src/sub.js:21:8

Node.js v18.12.1
```

Polyfill'ing `WebSocket` in `relay.ts` seems to fix this.