### PR TITLE
Turn `.publish()` into a normal async function returning a promise

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,13 +108,7 @@ let event = {
 event.id = getEventHash(event)
 event.sig = getSignature(event, sk)
 
-let pub = relay.publish(event)
-pub.on('ok', () => {
-  console.log(`${relay.url} has accepted our event`)
-})
-pub.on('failed', reason => {
-  console.log(`failed to publish to ${relay.url}: ${reason}`)
-})
+await relay.publish(event)
 
 let events = await relay.list([{kinds: [0, 1]}])
 let event = await relay.get({

--- a/nip42.ts
+++ b/nip42.ts
@@ -17,7 +17,9 @@ export const authenticate = async ({
 }: {
   challenge: string
   relay: Relay
-  sign: <K extends number = number>(e: EventTemplate<K>) => Promise<Event<K>> | Event<K>
+  sign: <K extends number = number>(
+    e: EventTemplate<K>
+  ) => Promise<Event<K>> | Event<K>
 }): Promise<void> => {
   const e: EventTemplate = {
     kind: Kind.ClientAuth,
@@ -28,15 +30,5 @@ export const authenticate = async ({
     ],
     content: ''
   }
-  const pub = relay.auth(await sign(e))
-  return new Promise((resolve, reject) => {
-    pub.on('ok', function ok() {
-      pub.off('ok', ok)
-      resolve()
-    })
-    pub.on('failed', function fail(reason: string) {
-      pub.off('failed', fail)
-      reject(reason)
-    })
-  })
+  return relay.auth(await sign(e))
 }


### PR DESCRIPTION
this simplifies the code and makes the API more intuitive.

we used to need the event emitter thing because we were subscribing to the same relay to check if the event had been published, but that is not necessary now that we assume an OK response will always come.

closes https://github.com/nbd-wtf/nostr-tools/issues/262