### PR TITLE
Filter: let tag queries be undefined

### DIFF
--- a/filter.ts
+++ b/filter.ts
@@ -8,7 +8,7 @@ export type Filter<K extends number = Kind> = {
   until?: number
   limit?: number
   search?: string
-  [key: `#${string}`]: string[]
+  [key: `#${string}`]: string[] | undefined
 }
 
 export function matchFilter(
@@ -34,7 +34,7 @@ export function matchFilter(
       if (
         values &&
         !event.tags.find(
-          ([t, v]) => t === f.slice(1) && values.indexOf(v) !== -1
+          ([t, v]) => t === f.slice(1) && values!.indexOf(v) !== -1
         )
       )
         return false


### PR DESCRIPTION
The current type has this problem:

```ts
const filter: Filter = {};

// Uncaught TypeError: Cannot read properties of undefined (reading 'map')
filter['#e'].map(console.log)
```

All the keys in `Filter` are already optional with `?`. To make tag queries optional we need `| undefined`