### PR TITLE
fix(nip98): Add support for common HTTP methods

### DIFF
--- a/nip98.ts
+++ b/nip98.ts
@@ -10,7 +10,14 @@ import {utf8Decoder, utf8Encoder} from './utils'
 
 enum HttpMethod {
   Get = 'get',
+  Head = 'head',
   Post = 'post'
+  Put = 'put'
+  Delete = 'delete'
+  Connect = 'connect'
+  Options = 'options'
+  Trace = 'trace'
+  Patch = 'patch'
 }
 
 const _authorizationScheme = 'Nostr '
@@ -32,7 +39,7 @@ export async function getToken(
 ): Promise<string> {
   if (!loginUrl || !httpMethod)
     throw new Error('Missing loginUrl or httpMethod')
-  if (httpMethod !== HttpMethod.Get && httpMethod !== HttpMethod.Post)
+  if (!httpMethod in HttpMethod)
     throw new Error('Unknown httpMethod')
 
   const event = getBlankEvent(Kind.HttpAuth)


### PR DESCRIPTION
This PR adds common HTTP methods: HEAD, PUT, CONNECT, OPTIONS, TRACE and PATCH.
Ref: https://developer.mozilla.org/en-US/docs/Web/HTTP/Methods