### PR TITLE
Added eoseSubTimeout to pool's SubscriptionOptions

### DIFF
--- a/pool.ts
+++ b/pool.ts
@@ -91,7 +91,7 @@ export class SimplePool {
     let eoseTimeout = setTimeout(() => {
       eoseSent = true
       for (let cb of eoseListeners.values()) cb()
-    }, this.eoseSubTimeout)
+    }, opts?.eoseSubTimeout || this.eoseSubTimeout)
 
     relays
       .filter((r, i, a) => a.indexOf(r) == i)

--- a/relay.ts
+++ b/relay.ts
@@ -73,7 +73,7 @@ export type SubscriptionOptions = {
   verb?: 'REQ' | 'COUNT'
   skipVerification?: boolean
   alreadyHaveEvent?: null | ((id: string, relay: string) => boolean)
-  eoseSubTimeout: number
+  eoseSubTimeout?: number
 }
 
 const newListeners = (): {[TK in keyof RelayEvent]: RelayEvent[TK][]} => ({

--- a/relay.ts
+++ b/relay.ts
@@ -73,6 +73,7 @@ export type SubscriptionOptions = {
   verb?: 'REQ' | 'COUNT'
   skipVerification?: boolean
   alreadyHaveEvent?: null | ((id: string, relay: string) => boolean)
+  eoseSubTimeout: number
 }
 
 const newListeners = (): {[TK in keyof RelayEvent]: RelayEvent[TK][]} => ({


### PR DESCRIPTION
This allows SimplePool users to specify a custom eoseSubTimeout for a single subscription instead of for the whole pool instance.