### PR TITLE
verifySignature: return false if the id is invalid

### DIFF
--- a/event.test.ts
+++ b/event.test.ts
@@ -278,6 +278,27 @@ describe('Event', () => {
 
       expect(isValid).toEqual(false)
     })
+
+    it('should return false for an invalid event id', () => {
+      const privateKey = 'd217c1ff2f8a65c3e3a1740db3b9f58b8c848bb45e26d00ed4714e4a0f4ceecf'
+
+      const event = finishEvent(
+        {
+          kind: 1,
+          tags: [],
+          content: 'Hello, world!',
+          created_at: 1617932115,
+        },
+        privateKey,
+      )
+
+      // tamper with the id
+      event.id = event.id.replace(/0/g, '1')
+
+      const isValid = verifySignature(event)
+
+      expect(isValid).toEqual(false)
+    })
   })
 
   describe('getSignature', () => {
@@ -296,9 +317,9 @@ describe('Event', () => {
       const sig = getSignature(unsignedEvent, privateKey)
 
       // verify the signature
-      // @ts-expect-error
       const isValid = verifySignature({
         ...unsignedEvent,
+        id: getEventHash(unsignedEvent),
         sig,
       })
 

--- a/event.test.ts
+++ b/event.test.ts
@@ -7,6 +7,7 @@ import {
   verifySignature,
   getSignature,
   Kind,
+  verifiedSymbol,
 } from './event.ts'
 import { getPublicKey } from './keys.ts'
 
@@ -236,7 +237,7 @@ describe('Event', () => {
     it('should return false for an invalid event signature', () => {
       const privateKey = 'd217c1ff2f8a65c3e3a1740db3b9f58b8c848bb45e26d00ed4714e4a0f4ceecf'
 
-      const event = finishEvent(
+      const { [verifiedSymbol]: _, ...event } = finishEvent(
         {
           kind: Kind.Text,
           tags: [],
@@ -260,7 +261,7 @@ describe('Event', () => {
       const privateKey2 = '5b4a34f4e4b23c63ad55a35e3f84a3b53d96dbf266edf521a8358f71d19cbf67'
       const publicKey2 = getPublicKey(privateKey2)
 
-      const event = finishEvent(
+      const { [verifiedSymbol]: _, ...event } = finishEvent(
         {
           kind: Kind.Text,
           tags: [],
@@ -282,7 +283,7 @@ describe('Event', () => {
     it('should return false for an invalid event id', () => {
       const privateKey = 'd217c1ff2f8a65c3e3a1740db3b9f58b8c848bb45e26d00ed4714e4a0f4ceecf'
 
-      const event = finishEvent(
+      const { [verifiedSymbol]: _, ...event } = finishEvent(
         {
           kind: 1,
           tags: [],

--- a/event.test.ts
+++ b/event.test.ts
@@ -248,7 +248,7 @@ describe('Event', () => {
       )
 
       // tamper with the signature
-      event.sig = event.sig.replace(/0/g, '1')
+      event.sig = event.sig.replace(/^.{3}/g, '666')
 
       const isValid = verifySignature(event)
 
@@ -294,7 +294,7 @@ describe('Event', () => {
       )
 
       // tamper with the id
-      event.id = event.id.replace(/0/g, '1')
+      event.id = event.id.replace(/^.{3}/g, '666')
 
       const isValid = verifySignature(event)
 

--- a/event.ts
+++ b/event.ts
@@ -71,11 +71,12 @@ export function getBlankEvent<K>(kind: K | Kind.Blank = Kind.Blank) {
   }
 }
 
-export function finishEvent<K extends number = number>(t: EventTemplate<K>, privateKey: string): Event<K> {
-  let event = t as Event<K>
+export function finishEvent<K extends number = number>(t: EventTemplate<K>, privateKey: string): VerifiedEvent<K> {
+  const event = t as VerifiedEvent<K>
   event.pubkey = getPublicKey(privateKey)
   event.id = getEventHash(event)
   event.sig = getSignature(event, privateKey)
+  event[verifiedSymbol] = true
   return event
 }
 

--- a/event.ts
+++ b/event.ts
@@ -119,14 +119,13 @@ export function verifySignature<K extends number>(event: Event<K>): event is Ver
 
   const hash = getEventHash(event)
   if (hash !== event.id) {
-    return false
+    return (event[verifiedSymbol] = false)
   }
 
   try {
-    event[verifiedSymbol] = schnorr.verify(event.sig, hash, event.pubkey)
-    return event[verifiedSymbol]
+    return (event[verifiedSymbol] = schnorr.verify(event.sig, hash, event.pubkey))
   } catch (err) {
-    return false
+    return (event[verifiedSymbol] = false)
   }
 }
 

--- a/event.ts
+++ b/event.ts
@@ -115,8 +115,14 @@ export function validateEvent<T>(event: T): event is T & UnsignedEvent<number> {
 /** Verify the event's signature. This function mutates the event with a `verified` symbol, making it idempotent. */
 export function verifySignature<K extends number>(event: Event<K>): event is VerifiedEvent<K> {
   if (typeof event[verifiedSymbol] === 'boolean') return event[verifiedSymbol]
+
+  const hash = getEventHash(event)
+  if (hash !== event.id) {
+    return false
+  }
+
   try {
-    event[verifiedSymbol] = schnorr.verify(event.sig, getEventHash(event), event.pubkey)
+    event[verifiedSymbol] = schnorr.verify(event.sig, hash, event.pubkey)
     return event[verifiedSymbol]
   } catch (err) {
     return false

--- a/pool.ts
+++ b/pool.ts
@@ -79,10 +79,13 @@ export class SimplePool {
     let eosesMissing = relays.length
 
     let eoseSent = false
-    let eoseTimeout = setTimeout(() => {
-      eoseSent = true
-      for (let cb of eoseListeners.values()) cb()
-    }, opts?.eoseSubTimeout || this.eoseSubTimeout)
+    let eoseTimeout = setTimeout(
+      () => {
+        eoseSent = true
+        for (let cb of eoseListeners.values()) cb()
+      },
+      opts?.eoseSubTimeout || this.eoseSubTimeout,
+    )
 
     relays
       .filter((r, i, a) => a.indexOf(r) === i)


### PR DESCRIPTION
Follow up to #288 

Now `verifySignature` will return `false` if the event id is invalid, which is probably the right behavior since it's the only function that checks it (ie `validateEvent` does not check it).

I also made `finishEvent` now return a `VerifiedEvent`, since in that case we also know it's definitely verified.