### PR TITLE
Make TypeScript >= 5.0.0 an optional peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,14 @@
     "@scure/bip32": "1.3.1",
     "@scure/bip39": "1.2.1"
   },
+  "peerDependencies": {
+    "typescript": ">=5.0.0"
+  },
+  "peerDependenciesMeta": {
+    "typescript": {
+      "optional": true
+    }
+  },
   "keywords": [
     "decentralization",
     "social",


### PR DESCRIPTION
Another follow-up to #281, this adds TypeScript >= 5.0.0 as an optional peer dependency. Users of plain JavaScript should not get any errors or warnings, but if TypeScript less than 5 is installed, a warning will be shown.