### PR TITLE
relay: `sub.events` async iterator

### DIFF
--- a/relay.test.ts
+++ b/relay.test.ts
@@ -57,6 +57,19 @@ test('querying', async () => {
   expect(t2).toEqual(true)
 }, 10000)
 
+test('async iterator', async () => {
+  let sub = relay.sub([
+    {
+      ids: ['d7dd5eb3ab747e16f8d0212d53032ea2a7cadef53837e5a6c66d42849fcb9027'],
+    },
+  ])
+
+  for await (const event of sub.events) {
+    expect(event).toHaveProperty('id', 'd7dd5eb3ab747e16f8d0212d53032ea2a7cadef53837e5a6c66d42849fcb9027')
+    break
+  }
+})
+
 test('get()', async () => {
   let event = await relay.get({
     ids: ['d7dd5eb3ab747e16f8d0212d53032ea2a7cadef53837e5a6c66d42849fcb9027'],


### PR DESCRIPTION
Should allow an API like this:

```ts
const sub = relay.sub([{ kinds: [1] }])

for await (const event of sub.events) {
  console.log(event) // I'm a kind 1 event!
}
```

It run forever until you break out of it (with a `break`). If you want to run it in the background you would typically put it inside a separate async function that isn't awaited:

```ts
async function processFilters(filters: Filter[]) {
  const sub = relay.sub(filters)

  for await (const event of sub.events) {
    console.log(event) // I'm a kind 1 event!
  }
}

processFilters() // now it runs in the background
console.log('hello') // this works
```


Creating async generators out of event emitters in JS is inherently dirty, but the API for users is much nicer. This has not been thoroughly tested and there might be problems with it.