### PR TITLE
nip13: use a simpler implementation

### DIFF
--- a/nip13.ts
+++ b/nip13.ts
@@ -1,42 +1,16 @@
-import { hexToBytes } from '@noble/hashes/utils'
-
 /** Get POW difficulty from a Nostr hex ID. */
-export function getPow(id: string): number {
-  return getLeadingZeroBits(hexToBytes(id))
-}
+export function getPow(hex: string): number {
+  let count = 0
 
-/**
- * Get number of leading 0 bits. Adapted from nostream.
- * https://github.com/Cameri/nostream/blob/fb6948fd83ca87ce552f39f9b5eb780ea07e272e/src/utils/proof-of-work.ts
- */
-function getLeadingZeroBits(hash: Uint8Array): number {
-  let total: number, i: number, bits: number
-
-  for (i = 0, total = 0; i < hash.length; i++) {
-    bits = msb(hash[i])
-    total += bits
-    if (bits !== 8) {
+  for (let i = 0; i < hex.length; i++) {
+    const nibble = parseInt(hex[i], 16)
+    if (nibble === 0) {
+      count += 4
+    } else {
+      count += Math.clz32(nibble) - 28
       break
     }
   }
-  return total
-}
 
-/**
- * Adapted from nostream.
- * https://github.com/Cameri/nostream/blob/fb6948fd83ca87ce552f39f9b5eb780ea07e272e/src/utils/proof-of-work.ts
- */
-function msb(b: number) {
-  let n = 0
-
-  if (b === 0) {
-    return 8
-  }
-
-  // eslint-disable-next-line no-cond-assign
-  while ((b >>= 1)) {
-    n++
-  }
-
-  return 7 - n
+  return count
 }


### PR DESCRIPTION
When I created the nip13 module, for some reason I glossed over the fact there was already a JavaScript implementation within the NIP-13 text itself: https://github.com/nostr-protocol/nips/blob/master/13.md#validating

I had pulled the implementation from Nostream, which is for Node.js, and adapted it to work in the browser. But apparently if you just do it the browser way it's much simpler.