### PR TITLE
Draft: Use dynamic imports to chunk noble deps

### DIFF
--- a/keys.ts
+++ b/keys.ts
@@ -1,10 +1,17 @@
-import { schnorr } from '@noble/curves/secp256k1'
-import { bytesToHex } from '@noble/hashes/utils'
+export async function generatePrivateKey(): Promise<string> {
+  const [{ schnorr }, { bytesToHex }] = await Promise.all([
+    import('@noble/curves/secp256k1'),
+    import('@noble/hashes/utils')
+  ])
 
-export function generatePrivateKey(): string {
   return bytesToHex(schnorr.utils.randomPrivateKey())
 }
 
-export function getPublicKey(privateKey: string): string {
+export async function getPublicKey(privateKey: string): Promise<string> {
+  const [{ schnorr }, { bytesToHex }] = await Promise.all([
+    import('@noble/curves/secp256k1'),
+    import('@noble/hashes/utils')
+  ])
+
   return bytesToHex(schnorr.getPublicKey(privateKey))
 }

--- a/nip13.test.ts
+++ b/nip13.test.ts
@@ -7,7 +7,7 @@ test('identifies proof-of-work difficulty', async () => {
 })
 
 test('mines POW for an event', async () => {
-  const difficulty = 10
+  const difficulty = 20
 
   const event = minePow({
     kind: 1,


### PR DESCRIPTION
This is an experiment. Do not merge. It breaks everything by changing the functions into async functions.

Just an idea I had while thinking about #296. For some reason I thought the functions were already async, in which case this would be perfect. But since they aren't we can't do this.

By using dynamic imports, the bundler will create chunks, and it will actually wait for the browser to load the chunk before proceeding. This will improve the initial load time at the cost of the first call to the function being slower (certain tools can precache chunks, though).

It might actually be possible to do this for the async functions like `nip04.encrypt` and `nip04.decrypt`.