### PR TITLE
Organize build, allow one entrypoint per file

### DIFF
--- a/build.js
+++ b/build.js
@@ -2,9 +2,17 @@
 
 const fs = require('fs')
 const esbuild = require('esbuild')
+const { join } = require('path');
+
+const entryPoints = fs.readdirSync(process.cwd())
+  .filter(
+    (file) =>
+      file.endsWith(".ts") && !file.endsWith("test.ts") &&
+      fs.statSync(join(process.cwd(), file)).isFile()
+  );
 
 let common = {
-  entryPoints: ['index.ts'],
+  entryPoints,
   bundle: true,
   sourcemap: 'external',
 }
@@ -12,7 +20,7 @@ let common = {
 esbuild
   .build({
     ...common,
-    outfile: 'lib/esm/nostr.mjs',
+    outdir: 'lib/esm',
     format: 'esm',
     packages: 'external',
   })
@@ -26,7 +34,7 @@ esbuild
 esbuild
   .build({
     ...common,
-    outfile: 'lib/nostr.cjs.js',
+    outdir: 'lib/cjs',
     format: 'cjs',
     packages: 'external',
   })
@@ -35,6 +43,7 @@ esbuild
 esbuild
   .build({
     ...common,
+    entryPoints: ['index.ts'],
     outfile: 'lib/nostr.bundle.js',
     format: 'iife',
     globalName: 'NostrTools',

--- a/package.json
+++ b/package.json
@@ -7,15 +7,143 @@
     "url": "https://github.com/nbd-wtf/nostr-tools.git"
   },
   "files": [
-    "./lib/**/*"
+    "lib"
   ],
-  "types": "./lib/index.d.ts",
-  "main": "lib/nostr.cjs.js",
-  "module": "lib/esm/nostr.mjs",
+  "sideEffects": false,
+  "module": "lib/esm/index.js",
+  "main": "lib/cjs/index.js",
+  "types": "lib/types/index.d.ts",
   "exports": {
-    "import": "./lib/esm/nostr.mjs",
-    "require": "./lib/nostr.cjs.js",
-    "types": "./lib/index.d.ts"
+    ".": {
+      "import": "lib/esm/index.js",
+      "require": "lib/cjs/index.js",
+      "types": "lib/types/index.d.ts"
+    },
+    "./keys": {
+      "import": "lib/esm/keys.js",
+      "require": "lib/cjs/keys.js",
+      "types": "lib/types/keys.d.ts"
+    },
+    "./relay": {
+      "import": "lib/esm/relay.js",
+      "require": "lib/cjs/relay.js",
+      "types": "lib/types/relay.d.ts"
+    },
+    "./event": {
+      "import": "lib/esm/event.js",
+      "require": "lib/cjs/event.js",
+      "types": "lib/types/event.d.ts"
+    },
+    "./filter": {
+      "import": "lib/esm/filter.js",
+      "require": "lib/cjs/filter.js",
+      "types": "lib/types/filter.d.ts"
+    },
+    "./pool": {
+      "import": "lib/esm/pool.js",
+      "require": "lib/cjs/pool.js",
+      "types": "lib/types/pool.d.ts"
+    },
+    "./references": {
+      "import": "lib/esm/references.js",
+      "require": "lib/cjs/references.js",
+      "types": "lib/types/references.d.ts"
+    },
+    "./nip04": {
+      "import": "lib/esm/nip04.js",
+      "require": "lib/cjs/nip04.js",
+      "types": "lib/types/nip04.d.ts"
+    },
+    "./nip05": {
+      "import": "lib/esm/nip05.js",
+      "require": "lib/cjs/nip05.js",
+      "types": "lib/types/nip05.d.ts"
+    },
+    "./nip06": {
+      "import": "lib/esm/nip06.js",
+      "require": "lib/cjs/nip06.js",
+      "types": "lib/types/nip06.d.ts"
+    },
+    "./nip10": {
+      "import": "lib/esm/nip10.js",
+      "require": "lib/cjs/nip10.js",
+      "types": "lib/types/nip10.d.ts"
+    },
+    "./nip13": {
+      "import": "lib/esm/nip13.js",
+      "require": "lib/cjs/nip13.js",
+      "types": "lib/types/nip13.d.ts"
+    },
+    "./nip18": {
+      "import": "lib/esm/nip18.js",
+      "require": "lib/cjs/nip18.js",
+      "types": "lib/types/nip18.d.ts"
+    },
+    "./nip19": {
+      "import": "lib/esm/nip19.js",
+      "require": "lib/cjs/nip19.js",
+      "types": "lib/types/nip19.d.ts"
+    },
+    "./nip21": {
+      "import": "lib/esm/nip21.js",
+      "require": "lib/cjs/nip21.js",
+      "types": "lib/types/nip21.d.ts"
+    },
+    "./nip25": {
+      "import": "lib/esm/nip25.js",
+      "require": "lib/cjs/nip25.js",
+      "types": "lib/types/nip25.d.ts"
+    },
+    "./nip26": {
+      "import": "lib/esm/nip26.js",
+      "require": "lib/cjs/nip26.js",
+      "types": "lib/types/nip26.d.ts"
+    },
+    "./nip27": {
+      "import": "lib/esm/nip27.js",
+      "require": "lib/cjs/nip27.js",
+      "types": "lib/types/nip27.d.ts"
+    },
+    "./nip28": {
+      "import": "lib/esm/nip28.js",
+      "require": "lib/cjs/nip28.js",
+      "types": "lib/types/nip28.d.ts"
+    },
+    "./nip39": {
+      "import": "lib/esm/nip39.js",
+      "require": "lib/cjs/nip39.js",
+      "types": "lib/types/nip39.d.ts"
+    },
+    "./nip42": {
+      "import": "lib/esm/nip42.js",
+      "require": "lib/cjs/nip42.js",
+      "types": "lib/types/nip42.d.ts"
+    },
+    "./nip44": {
+      "import": "lib/esm/nip44.js",
+      "require": "lib/cjs/nip44.js",
+      "types": "lib/types/nip44.d.ts"
+    },
+    "./nip57": {
+      "import": "lib/esm/nip57.js",
+      "require": "lib/cjs/nip57.js",
+      "types": "lib/types/nip57.d.ts"
+    },
+    "./nip98": {
+      "import": "lib/esm/nip98.js",
+      "require": "lib/cjs/nip98.js",
+      "types": "lib/types/nip98.d.ts"
+    },
+    "./fakejson": {
+      "import": "lib/esm/fakejson.js",
+      "require": "lib/cjs/fakejson.js",
+      "types": "lib/types/fakejson.d.ts"
+    },
+    "./utils": {
+      "import": "lib/esm/utils.js",
+      "require": "lib/cjs/utils.js",
+      "types": "lib/types/utils.d.ts"
+    }
   },
   "license": "Unlicense",
   "dependencies": {
@@ -42,7 +170,7 @@
     "nostr"
   ],
   "scripts": {
-    "build": "node build",
+    "build": "node build && tsc",
     "format": "prettier --plugin-search-dir . --write .",
     "test": "jest"
   },

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,7 +9,7 @@
     "skipLibCheck": true,
     "esModuleInterop": true,
     "emitDeclarationOnly": true,
-    "outDir": "lib",
+    "outDir": "lib/types",
     "rootDir": ".",
     "allowImportingTsExtensions": true
   }


### PR DESCRIPTION
Adds one entrypoint per file such that `import { generatePrivateKey } from 'nostr-tools/keys';` can be done from clients without having to import everything but the kitchen sink. For ESM and CJS, the IIFE version still bundles from `index.ts`