### PR TITLE
Clean up test with a minor refactor to delete the ts-ignore

### DIFF
--- a/pool.test.ts
+++ b/pool.test.ts
@@ -104,12 +104,8 @@ test('list()', async () => {
   )
 
   // the actual received number will be greater than 2, but there will be no duplicates
-  expect(events.length).toEqual(
-    events
-      .map(evt => evt.id)
-      // @ts-ignore ???
-      .reduce((acc, n) => (acc.indexOf(n) !== -1 ? acc : [...acc, n]), []).length,
-  )
+  const uniqueEventCount = new Set(events.map(evt => evt.id)).size
+  expect(events.length).toEqual(uniqueEventCount)
 
   let relaysForAllEvents = events.map(event => pool.seenOn(event.id)).reduce((acc, n) => acc.concat(n), [])
   expect(relaysForAllEvents.length).toBeGreaterThanOrEqual(events.length)


### PR DESCRIPTION
I'd like to advocate that for eliminating as many "ts-ignores" and "eslint-ignores" as possible to ensure the code base remains strongly typed throughout. This one is a bit of nitpick as it's in a test assertion, but my OCD couldn't let it slide. :)

I will follow up soon with another more meaningful one that isn't inside a test file.