### PR TITLE
add verifyPow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ package-lock.json
 .envrc
 lib
 test.html
+bun.lockb

--- a/nip13.test.ts
+++ b/nip13.test.ts
@@ -1,4 +1,6 @@
-import { getPow, minePow } from './nip13.ts'
+import { getPow, minePow, verifyPow } from './nip13.ts'
+import { getPublicKey } from './keys.ts'
+import { type UnsignedEvent, type Event, getEventHash, finishEvent } from './event.ts'
 
 test('identifies proof-of-work difficulty', async () => {
   const id = '000006d8c378af1779d2feebc7603a125d99eca0ccf1085959b307f64e5dd358'
@@ -21,4 +23,103 @@ test('mines POW for an event', async () => {
   )
 
   expect(getPow(event.id)).toBeGreaterThanOrEqual(difficulty)
+})
+
+function fakePow<K extends number>(unsigned: UnsignedEvent<K>, targetDifficulty: number, difficulty: number): Omit<Event<K>, 'sig'> {
+  let count = 0
+
+  const event = unsigned as Omit<Event<K>, 'sig'>
+  const tag = ['nonce', count.toString(), targetDifficulty.toString()]
+
+  event.tags.push(tag)
+
+  while (true) {
+    const now = Math.floor(new Date().getTime() / 1000)
+
+    if (now !== event.created_at) {
+      count = 0
+      event.created_at = now
+    }
+
+    tag[1] = (++count).toString()
+
+    event.id = getEventHash(event)
+
+    if (getPow(event.id) >= difficulty) {
+      break
+    }
+  }
+
+  return event
+}
+
+describe('verifyPow', () => {
+  it('should return difficulty 10', () => {
+    const difficulty = 10
+
+    const privateKey = 'd217c1ff2f8a65c3e3a1740db3b9f58b8c848bb45e26d00ed4714e4a0f4ceecf'
+    const publicKey = getPublicKey(privateKey)
+    const unsignedEvent = minePow(
+      {
+        kind: 1,
+        tags: [],
+        content: 'Hello, world!',
+        created_at: 0,
+        pubkey: publicKey,
+      },
+      difficulty,
+    )
+
+    const event = finishEvent(unsignedEvent, privateKey);
+
+    expect(verifyPow(event)).toBeGreaterThanOrEqual(difficulty)
+  })
+
+  it('should return difficulty 0 for no nonce tag', () => {
+    const difficulty = 10
+
+    const privateKey = 'd217c1ff2f8a65c3e3a1740db3b9f58b8c848bb45e26d00ed4714e4a0f4ceecf'
+    const publicKey = getPublicKey(privateKey)
+    const unsignedEvent = minePow(
+      {
+        kind: 1,
+        tags: [],
+        content: 'Hello, world!',
+        created_at: 0,
+        pubkey: publicKey,
+      },
+      difficulty,
+    )
+
+    const event = finishEvent(unsignedEvent, privateKey);
+
+    let noNonceTagEvent = event;
+    noNonceTagEvent.tags = [];
+
+    expect(verifyPow(noNonceTagEvent)).toEqual(0)
+  })
+
+  it('should return difficulty 5- target difficulty is lower than difficulty from hash', () => {
+    const targetDifficulty = 5
+    const difficulty = 10
+
+    const privateKey = 'd217c1ff2f8a65c3e3a1740db3b9f58b8c848bb45e26d00ed4714e4a0f4ceecf'
+    const publicKey = getPublicKey(privateKey)
+    const unsignedEvent = fakePow(
+      {
+        kind: 1,
+        tags: [],
+        content: 'Hello, world!',
+        created_at: 0,
+        pubkey: publicKey,
+      },
+      targetDifficulty,
+      difficulty
+    )
+
+    const event = finishEvent(unsignedEvent, privateKey);
+
+    expect(verifyPow(event)).toBeLessThan(getPow(event.id))
+    expect(verifyPow(event)).toEqual(targetDifficulty)
+  })
 })


### PR DESCRIPTION
think this may be worth adding.

for my app [get-tao.app](https://www.get-tao.app/), we use PoW filtering and also PoW sorting.
technically the proof side depends on what the user was targeting in the first place.

it's a minor issue at the moment, but ive noticed some notes get onto my high PoW feed while actually targeting a lower difficulty, which indicates the work they've actually put in.
you can see the basic idea with the bottom test. 