### PR TITLE
Update `@noble/curves` to 1.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -148,7 +148,7 @@
   "license": "Unlicense",
   "dependencies": {
     "@noble/ciphers": "0.2.0",
-    "@noble/curves": "1.1.0",
+    "@noble/curves": "1.2.0",
     "@noble/hashes": "1.3.1",
     "@scure/base": "1.1.1",
     "@scure/bip32": "1.3.1",


### PR DESCRIPTION
There was a bug in the package `@noble/curves` with version 1.1.0 when parsing strings with non-hex characters. It will not throw any error but keep processing with the wrong formatted string.

Here's the steps to re-produce:

```
const { getPublicKey } = require('nostr-tools')
const sk = "02336e32749f642c6a56ee709a01afe7ff8d2b268c04a7f;a0000308cd2382eb"
const pk = getPublicKey(sk)
```

The variable `sk` contains a non-hexadecimal character, I believe the function call `getPublicKey()` should throw an error here but it's keeping converting it to a public key.

<img width="1007" alt="image" src="https://github.com/nbd-wtf/nostr-tools/assets/4447759/5cb0a04c-f72b-4402-8fa9-3977626ad9f3">

