### PR TITLE
Updating nip06 privateKeyFromSeedWords function 

### DIFF
--- a/nip06.ts
+++ b/nip06.ts
@@ -3,9 +3,10 @@ import { wordlist } from '@scure/bip39/wordlists/english'
 import { generateMnemonic, mnemonicToSeedSync, validateMnemonic } from '@scure/bip39'
 import { HDKey } from '@scure/bip32'
 
-export function privateKeyFromSeedWords(mnemonic: string, passphrase?: string): string {
+export function privateKeyFromSeedWords(mnemonic: string, passphrase?: string, account: number = 0, change : number = 0, index: number = 0): string {
   let root = HDKey.fromMasterSeed(mnemonicToSeedSync(mnemonic, passphrase))
-  let privateKey = root.derive(`m/44'/1237'/0'/0/0`).privateKey
+  let derivationPath = `m/44'/1237'/${account}'/${change}/${index}`
+  let privateKey = root.derive(derivationPath).privateKey
   if (!privateKey) throw new Error('could not derive private key')
   return bytesToHex(privateKey)
 }


### PR DESCRIPTION
## This pull request updates the nip06 function privateKeyFromSeedWords().

Previously, you were only allowed to get one private key from a seed phrase. I added the optional parameters "account", "change" and "index" which allows you to derive many private keys from one seed phrase.

The parameters are optional, and this change should be backward compatible.

