### PR TITLE
Added bytesToHex for nsec and npub decoding

### DIFF
--- a/nip19.ts
+++ b/nip19.ts
@@ -130,9 +130,11 @@ export function decode(nip19: string): DecodeResult {
     }
 
     case 'nsec':
-      return { type: prefix, data }
+      return { type: prefix, data: bytesToHex(data) }
 
     case 'npub':
+      return { type: prefix, data: bytesToHex(data) }
+
     case 'note':
       return { type: prefix, data: bytesToHex(data) }
 


### PR DESCRIPTION
The data value for nsec was returning as an Uint8Array rather than a hex string because the bytesToHex conversion wasn't being applied.