### PR TITLE
fix yield

### DIFF
--- a/relay.ts
+++ b/relay.ts
@@ -12,6 +12,15 @@ export function relayConnect(url: string) {
   return relay
 }
 
+async function yieldThread() {
+  return new Promise((resolve) => {
+    const ch = new MessageChannel();
+    ch.port1.addEventListener('message', () => resolve());
+    ch.port2.postMessage(0);
+    ch.port1.start();
+  });
+}
+
 export class Relay {
   public readonly url: string
   private _connected: boolean = false
@@ -117,7 +126,7 @@ export class Relay {
       if (false === this.handleNext()) {
         break
       }
-      await Promise.resolve()
+      await yieldThread()
     }
     this.queueRunning = false
   }


### PR DESCRIPTION
This PR support ["yield"](https://en.wikipedia.org/wiki/Yield_(multithreading)) which was done in the previous version.

## Why

In the previous version, there were short sleep before starting to process the next event.
https://github.com/nbd-wtf/nostr-tools/blob/318e3f8c8867cb183684622cdedf6a9ee49cee78/relay.ts#L114

This short sleep allows queued tasks such as click, key input and rendering HTML to be processed in event loop of JavaScript engine. This will enhance user experience in especially browsers in the situation when the browser need to process a large amount of events.

In the current version 2.0.0, it seems that the code is trying to do the same thing.
https://github.com/nbd-wtf/nostr-tools/blob/8f0311668730b81138d18296521f8f396bb8612e/relay.ts#L114-L123

But I think it doesn't work. I checked this with this code.

```javascript
(async () => {
  while (true) {
    await Promise.resolve();
  }
})();
```

If it works well, I can click buttons or input some letters in the input element but I couldn't.

This PR introduces short sleep using `MessageChannel`.

## Alternative ways

There were several ways to realize short sleep: `setTimeout` and `setImmediate`, but there are some cons.

- setTimeout is slow.
    - In the old version of V8 or some other runtime, callback of `setTimeout(..., 0)` is executed after 4 or 5 ms later in reality.
        - https://stackoverflow.com/questions/9647215/what-is-minimum-millisecond-value-of-settimeout
    - As for the latest environment, this delay is shorter than before but MessageChannel is still fast.
        - In my environment, MessageChannel is 54 times faster than setTimeout.
        - https://gist.github.com/syusui-s/4413d7beaec8e2cf9b5eaf20ad3bf22a
- setImmediate was deprecated
    - There is no setImmediate in the latest Chrome and Firefox.
    - https://developer.mozilla.org/en-US/docs/Web/API/Window/setImmediate

