### PR TITLE
ensureRelay reconnect

### DIFF
--- a/pool.ts
+++ b/pool.ts
@@ -28,8 +28,8 @@ export class SimplePool {
       if (params?.connectionTimeout) relay.connectionTimeout = params.connectionTimeout
       if (this.trustedRelayURLs.has(relay.url)) relay.trusted = true
       this.relays.set(url, relay)
-      await relay.connect()
     }
+    await relay.connect()
 
     return relay
   }


### PR DESCRIPTION
The current implementation of `ensureRelay` connects to relays **for the first time only**. The second invocation of `ensureRelay` doesn't try to reconnect the relay even if it is disconnected. 

This PR fixes that. It will try to connect if `relay` is disconnected.

## Detail

The current implementation tries to send messages even if the connection is closed.
It causes the following error when I call `pool.subscribeMany([failedRelay], ...)`:

```
Uncaught (in promise) Error: sending on closed connection
```

https://github.com/nbd-wtf/nostr-tools/blob/a9acdada19e11ebb226e9decaae3533a51ca4010/pool.ts#L106

If this PR is merged, the connection error exception will be raised in this `try` block and it will be handled correctly.

https://github.com/nbd-wtf/nostr-tools/blob/a9acdada19e11ebb226e9decaae3533a51ca4010/pool.ts#L97-L104

