### PR TITLE
export kinds

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -23,5 +23,6 @@ export * as nip47 from './nip47.ts'
 export * as nip57 from './nip57.ts'
 export * as nip98 from './nip98.ts'
 
+export * as kinds from './kinds.ts'
 export * as fj from './fakejson.ts'
 export * as utils from './utils.ts'

--- a/package.json
+++ b/package.json
@@ -29,6 +29,11 @@
       "require": "./lib/cjs/wasm.js",
       "types": "./lib/types/wasm.d.ts"
     },
+    "./kinds": {
+      "import": "./lib/esm/kinds.js",
+      "require": "./lib/cjs/kinds.js",
+      "types": "./lib/types/kinds.d.ts"
+    },
     "./filter": {
       "import": "./lib/esm/filter.js",
       "require": "./lib/cjs/filter.js",


### PR DESCRIPTION
I tried to import kinds from `nostr-tools/kinds` but it seems that it is not exported.

```
[vite] Internal server error: Missing "./kinds" specifier in "nostr-tools" package
```

This PR fixes that.