### PR TITLE
fix problem when required from CommonJS

### DIFF
--- a/build.js
+++ b/build.js
@@ -27,12 +27,7 @@ esbuild
     format: 'esm',
     packages: 'external',
   })
-  .then(() => {
-    const packageJson = JSON.stringify({ type: 'module' })
-    fs.writeFileSync(`${__dirname}/lib/esm/package.json`, packageJson, 'utf8')
-
-    console.log('esm build success.')
-  })
+  .then(() => console.log('esm build success.'))
 
 esbuild
   .build({
@@ -41,7 +36,12 @@ esbuild
     format: 'cjs',
     packages: 'external',
   })
-  .then(() => console.log('cjs build success.'))
+  .then(() => {
+    const packageJson = JSON.stringify({ type: 'commonjs' })
+    fs.writeFileSync(`${__dirname}/lib/cjs/package.json`, packageJson, 'utf8')
+
+    console.log('cjs build success.')
+  })
 
 esbuild
   .build({


### PR DESCRIPTION
When CommonJS modules of this package are imported from node scripts under the "CJS context", an error occurs:

```
Error [ERR_REQUIRE_ESM]: require() of ES Module /...snip.../node_modules/nostr-tools/lib/cjs/index.js from /...snip.../user_script.js not supported.
index.js is treated as an ES module file as it is a .js file whose nearest parent package.json contains "type": "module" which declares all .js files in that package scope as ES modules.
```

This is due to [this change](https://github.com/nbd-wtf/nostr-tools/commit/7f11c0c618449579bac0b38ca2bc4cef6cbd4b2b#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R2), and I fixed it by applying [this hack](https://github.com/nbd-wtf/nostr-tools/blob/f727058a3a38ac4021f9e01d3772a320f4d3e4a3/build.js#L31-L36) to the CJS build instead of the ESM build.