### PR TITLE
fix yieldThread memory leak

### DIFF
--- a/helpers.ts
+++ b/helpers.ts
@@ -1,10 +1,15 @@
 import { verifiedSymbol, type Event, type Nostr, VerifiedEvent } from './core.ts'
 
 export async function yieldThread() {
-  return new Promise(resolve => {
+  return new Promise<void>(resolve => {
     const ch = new MessageChannel()
+    const handler = () => {
+      // @ts-ignore (typescript thinks this property should be called `removeListener`, but in fact it's `removeEventListener`)
+      ch.port1.removeEventListener('message', handler)
+      resolve()
+    }
     // @ts-ignore (typescript thinks this property should be called `addListener`, but in fact it's `addEventListener`)
-    ch.port1.addEventListener('message', resolve)
+    ch.port1.addEventListener('message', handler)
     ch.port2.postMessage(0)
     ch.port1.start()
   })


### PR DESCRIPTION
I noticed that the current implementation of yieldThread will consume memory.
The message channel will never be used after the call but there is still a `'message'` call-back function so GC cannot free it.

It is needed to call `removeEventHandler`.

## Detail
If you run this script with `node` command like `node script.js`, the process will never finish.

```javascript
async function yieldThread() {
  return new Promise(resolve => {
    const ch = new MessageChannel()
    ch.port1.addEventListener('message', resolve)
    ch.port2.postMessage(0)
    ch.port1.start()
  })
}

yieldThread()
```

If there is removeEventListener, it will finish successfully.

```javascript
async function yieldThread() {
  return new Promise(resolve => {
    const ch = new MessageChannel()
    const handler = () => {
      ch.port1.removeEventListener('message', handler)
      resolve()
    }
    ch.port1.addEventListener('message', handler)
    ch.port2.postMessage(0)
    ch.port1.start()
  })
}

yieldThread();
```