### PR TITLE
Add getFilterLimit function

### DIFF
--- a/filter.test.ts
+++ b/filter.test.ts
@@ -1,5 +1,5 @@
 import { describe, test, expect } from 'bun:test'
-import { matchFilter, matchFilters, mergeFilters } from './filter.ts'
+import { getFilterLimit, matchFilter, matchFilters, mergeFilters } from './filter.ts'
 import { buildEvent } from './test-helpers.ts'
 
 describe('Filter', () => {
@@ -239,6 +239,29 @@ describe('Filter', () => {
       expect(
         mergeFilters({ kinds: [1], since: 15, until: 30 }, { since: 10, kinds: [7], until: 15 }, { kinds: [9, 10] }),
       ).toEqual({ kinds: [1, 7, 9, 10], since: 10, until: 30 })
+    })
+  })
+
+  describe('getFilterLimit', () => {
+    test('should handle ids', () => {
+      expect(getFilterLimit({ ids: ['123'] })).toEqual(1)
+      expect(getFilterLimit({ ids: ['123'], limit: 2 })).toEqual(1)
+      expect(getFilterLimit({ ids: ['123'], limit: 0 })).toEqual(0)
+      expect(getFilterLimit({ ids: ['123'], limit: -1 })).toEqual(0)
+    })
+
+    test('should count the authors times replaceable kinds', () => {
+      expect(getFilterLimit({ kinds: [0], authors: ['alex'] })).toEqual(1)
+      expect(getFilterLimit({ kinds: [0, 3], authors: ['alex'] })).toEqual(2)
+      expect(getFilterLimit({ kinds: [0, 3], authors: ['alex', 'fiatjaf'] })).toEqual(4)
+    })
+
+    test('should return Infinity for authors with regular kinds', () => {
+      expect(getFilterLimit({ kinds: [1], authors: ['alex'] })).toEqual(Infinity)
+    })
+
+    test('should return Infinity for empty filters', () => {
+      expect(getFilterLimit({})).toEqual(Infinity)
     })
   })
 })

--- a/filter.ts
+++ b/filter.ts
@@ -1,4 +1,5 @@
 import { Event } from './core.ts'
+import { isReplaceableKind } from './kinds.ts'
 
 export type Filter = {
   ids?: string[]
@@ -69,4 +70,20 @@ export function mergeFilters(...filters: Filter[]): Filter {
   }
 
   return result
+}
+
+/** Calculate the intrinsic limit of a filter. This function may return `Infinity`. */
+export function getFilterLimit(filter: Filter): number {
+  if (filter.ids && !filter.ids.length) return 0
+  if (filter.kinds && !filter.kinds.length) return 0
+  if (filter.authors && !filter.authors.length) return 0
+
+  return Math.min(
+    Math.max(0, filter.limit ?? Infinity),
+    filter.ids?.length ?? Infinity,
+    filter.authors?.length &&
+      filter.kinds?.every((kind) => isReplaceableKind(kind))
+      ? filter.authors.length * filter.kinds.length
+      : Infinity,
+  )
 }


### PR DESCRIPTION
When filtering events, it can sometimes be difficult to know when to stop. Obviously if the filter has a `limit` you can use it, but otherwise you may need to rely on timeouts or other cues.

But some filters have an intrinsic limit. For example, `{ ids: ["a", "b", "c" }` has an intrinsic limit is `3`.

If an intrinsic limit can be determined from the filter, `getFilterLimit` will return it. Otherwise it will return `Infinity`.

This is useful in multiple scenarios:

1. You can skip invalid filters entirely with `filters.filter((filter) => getFilterLimit(filter) > 0)`. This technique is usable on both clients and relays.
2. If you are querying events from a storage, you can cancel when the limit is reached, saving time.
3. You can use it to calculate the desired limit on your own filters before sending them to storages, which might help them EOSE properly in case they don't already implement a feature like this internally.