### PR TITLE
handle connectionstrings with authority

### DIFF
--- a/nip47.test.ts
+++ b/nip47.test.ts
@@ -10,9 +10,19 @@ import { NWCWalletRequest } from './kinds.ts'
 globalThis.crypto = crypto
 
 describe('parseConnectionString', () => {
-  test('returns pubkey, relay, and secret if connection string is valid', () => {
+  test('returns pubkey, relay, and secret if connection string is valid and complies with spec', () => {
     const connectionString =
       'nostr+walletconnect:b889ff5b1513b641e2a139f661a661364979c5beee91842f8f0ef42ab558e9d4?relay=wss%3A%2F%2Frelay.damus.io&secret=71a8c14c1407c113601079c4302dab36460f0ccd0ad506f1f2dc73b5100e4f3c'
+    const { pubkey, relay, secret } = parseConnectionString(connectionString)
+
+    expect(pubkey).toBe('b889ff5b1513b641e2a139f661a661364979c5beee91842f8f0ef42ab558e9d4')
+    expect(relay).toBe('wss://relay.damus.io')
+    expect(secret).toBe('71a8c14c1407c113601079c4302dab36460f0ccd0ad506f1f2dc73b5100e4f3c')
+  })
+
+  test('returns pubkey, relay, and secret if connection string is valid, but uses authority instead of pathname', () => {
+    const connectionString =
+      'nostr+walletconnect://b889ff5b1513b641e2a139f661a661364979c5beee91842f8f0ef42ab558e9d4?relay=wss%3A%2F%2Frelay.damus.io&secret=71a8c14c1407c113601079c4302dab36460f0ccd0ad506f1f2dc73b5100e4f3c'
     const { pubkey, relay, secret } = parseConnectionString(connectionString)
 
     expect(pubkey).toBe('b889ff5b1513b641e2a139f661a661364979c5beee91842f8f0ef42ab558e9d4')

--- a/nip47.ts
+++ b/nip47.ts
@@ -3,8 +3,8 @@ import { NWCWalletRequest } from './kinds.ts'
 import { encrypt } from './nip04.ts'
 
 export function parseConnectionString(connectionString: string) {
-  const { pathname, searchParams } = new URL(connectionString)
-  const pubkey = pathname
+  const { pathname, host, searchParams } = new URL(connectionString)
+  const pubkey = connectionString.indexOf('//') === -1 ? pathname : host
   const relay = searchParams.get('relay')
   const secret = searchParams.get('secret')
 


### PR DESCRIPTION
This is a tiny change in the NIP-47 utilities to handle the very real case of a NWC provider using connection URIs that don't comply with the spec and instead use "schema://pubkey". This change ensure compatibility with both.

Examples of NWC providers that use Authority are:

- Alby
- Current
- Mutiny