### PR TITLE
nip19: implement nconnect1

### DIFF
--- a/nip19.test.ts
+++ b/nip19.test.ts
@@ -11,6 +11,8 @@ import {
   type AddressPointer,
   type ProfilePointer,
   EventPointer,
+  nconnectEncode,
+  type ConnectPointer,
 } from './nip19.ts'
 
 test('encode and decode nsec', () => {
@@ -160,4 +162,19 @@ test('encode and decode nrelay', () => {
   let { type, data } = decode(nrelay)
   expect(type).toEqual('nrelay')
   expect(data).toEqual(url)
+})
+
+test('encode and decode nconnect', () => {
+  let clientPubkey = getPublicKey(generateSecretKey())
+  let signerPubkey = getPublicKey(generateSecretKey())
+  let relays = ['wss://nostr.banana.com']
+  let nconnect = nconnectEncode({ clientPubkey, signerPubkey, relays, secret: 'yolo!' })
+  expect(nconnect).toMatch(/nconnect1\w+/)
+  let { type, data } = decode(nconnect)
+  expect(type).toEqual('nconnect')
+  const pointer = data as ConnectPointer
+  expect(pointer.clientPubkey).toEqual(clientPubkey)
+  expect(pointer.signerPubkey).toEqual(signerPubkey)
+  expect(pointer.relays).toContain(relays[0])
+  expect(pointer.secret).toEqual('yolo!')
 })


### PR DESCRIPTION
This has not been proposed anywhere or documented. I'm just experimenting with an idea.

`nconnect1` entities would replace `bunker://` URIs, which were never standardized in NIP-46. It would be for the signer-to-client flow.

Here's an example:

```
nconnect1qvzhjmmvdussy9nhwden5te0dehhxarj9e3xzmnpdesjucm0d5qjpa67j43h8maf2xmx6rma3szsetdlrue946ue2y3v6ya0hx2ptsexqqs9sstxc8ly2x46u5qs2lcx6ww24vkv2npp6jfhq3ye52n5ds0mghsc3uwhv
```

The nconnect entity contains both the signer's pubkey and the client's pubkey. The signer should have access to both, and including both allows it to be used as a complete authorization scheme that can be pasted into any box an npub or nsec can be pasted into. That's the goal of this.