### PR TITLE
Fix explicit file extension for core.ts

### DIFF
--- a/pure.ts
+++ b/pure.ts
@@ -1,6 +1,6 @@
 import { schnorr } from '@noble/curves/secp256k1'
 import { bytesToHex } from '@noble/hashes/utils'
-import { Nostr, Event, EventTemplate, UnsignedEvent, VerifiedEvent, verifiedSymbol, validateEvent } from './core'
+import { Nostr, Event, EventTemplate, UnsignedEvent, VerifiedEvent, verifiedSymbol, validateEvent } from './core.ts'
 import { sha256 } from '@noble/hashes/sha256'
 
 import { utf8Encoder } from './utils.ts'


### PR DESCRIPTION
Some imports do not have the explicit extension and others do. In this case I fix core.ts which is giving error in some of my projects that use nostr-tools.

![image](https://github.com/nbd-wtf/nostr-tools/assets/125748180/c1a1ab82-d741-4e80-b3c1-6f452e96b5d6)
