### PR TITLE
ignore HTTP redirect in nip05

### DIFF
--- a/nip05.ts
+++ b/nip05.ts
@@ -21,9 +21,10 @@ export function useFetchImplementation(fetchImplementation: any) {
 
 export async function searchDomain(domain: string, query = ''): Promise<{ [name: string]: string }> {
   try {
-    let res = await (await _fetch(`https://${domain}/.well-known/nostr.json?name=${query}`)).json()
-
-    return res.names
+    const url = `https://${domain}/.well-known/nostr.json?name=${query}`
+    const res = await _fetch(url, { redirect: 'error' })
+    const json = await res.json()
+    return json.names
   } catch (_) {
     return {}
   }
@@ -36,7 +37,8 @@ export async function queryProfile(fullname: string): Promise<ProfilePointer | n
   const [_, name = '_', domain] = match
 
   try {
-    const res = await _fetch(`https://${domain}/.well-known/nostr.json?name=${name}`)
+    const url = `https://${domain}/.well-known/nostr.json?name=${name}`
+    const res = await _fetch(url, { redirect: 'error' })
     const { names, relays } = parseNIP05Result(await res.json())
 
     const pubkey = names[name]


### PR DESCRIPTION
According to NIP-05 specification, the implementation must ignore HTTP redirect.

https://github.com/nostr-protocol/nips/blob/master/05.md#security-constraints

`fetch` API accepts the option as the second parameter.
`{ redirect: 'error' }` will cause an error if the endpoint returns 302 or something like that.
