### PR TITLE
Prepare for JSR publishing

### DIFF
--- a/jsr.json
+++ b/jsr.json
@@ -1,0 +1,5 @@
+{
+  "name": "@nostr/tools",
+  "version": "2.3.1",
+  "exports": "./index.ts"
+}


### PR DESCRIPTION
Adds the required `jsr.json` file. Then it can be deployed with `deno publish` or `npx jsr publish`.

We should also fix #375 