### PR TITLE
Fix pubkey param to nip46 connect

### DIFF
--- a/nip46.ts
+++ b/nip46.ts
@@ -193,7 +193,7 @@ export class BunkerSigner {
    * Calls the "connect" method on the bunker.
    */
   async connect(): Promise<void> {
-    await this.sendRequest('connect', [getPublicKey(this.secretKey), this.bp.secret || ''])
+    await this.sendRequest('connect', [this.bp.pubkey, this.bp.secret || ''])
   }
 
   /**


### PR DESCRIPTION
NIP46 requires remote_user_pubkey as first param to connect. Context: https://github.com/nostrability/nostrability/issues/25#issuecomment-2018748964