### PR TITLE
Add hyphen to BUNKER_REGEX

### DIFF
--- a/nip46.ts
+++ b/nip46.ts
@@ -17,7 +17,7 @@ export function useFetchImplementation(fetchImplementation: any) {
   _fetch = fetchImplementation
 }
 
-export const BUNKER_REGEX = /^bunker:\/\/([0-9a-f]{64})\??([?\/\w:.=&%]*)$/
+export const BUNKER_REGEX = /^bunker:\/\/([0-9a-f]{64})\??([?\/\w:.=&%-]*)$/
 const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/
 
 export type BunkerPointer = {


### PR DESCRIPTION
The hyphen (`-`) is missing in BUNKER_REGEX, this can invalidate some legit bunker urls when the `secret` contains this character.
https://datatracker.ietf.org/doc/html/rfc4648#section-5