### PR TITLE
Fix count request in anstract relay

### DIFF
--- a/abstract-relay.ts
+++ b/abstract-relay.ts
@@ -259,7 +259,7 @@ export class AbstractRelay {
     const ret = new Promise<number>((resolve, reject) => {
       this.openCountRequests.set(id, { resolve, reject })
     })
-    this.send('["COUNT","' + id + '",' + JSON.stringify(filters) + ']')
+    this.send('["COUNT","' + id + '",' + JSON.stringify(filters).substring(1))
     return ret
   }
 


### PR DESCRIPTION
The `count` method is wrapping the filters in an extra array. which makes it an invalid request according to [NIP-45](https://github.com/nostr-protocol/nips/blob/master/45.md#filters-and-return-values)

## Before
```json
["COUNT","count:1",[{"kinds":[1]}]]
```

## After
```json
["COUNT","count:1",{"kinds":[1]}]
```