### PR TITLE
including interface for nip07

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,6 +183,17 @@ import { useFetchImplementation } from 'nostr-tools/nip05'
 useFetchImplementation(require('node-fetch'))
 ```
 
+### Including NIP-07 types
+```js
+import { Nip07 } from 'nostr-tools'
+
+declare global {
+  interface Window {
+    nostr?: Nip07;
+  }
+}
+```
+
 ### Encoding and decoding NIP-19 codes
 
 ```js

--- a/README.md
+++ b/README.md
@@ -185,7 +185,7 @@ useFetchImplementation(require('node-fetch'))
 
 ### Including NIP-07 types
 ```js
-import { Nip07 } from 'nostr-tools'
+import { Nip07 } from 'nostr-tools/nip07'
 
 declare global {
   interface Window {

--- a/index.ts
+++ b/index.ts
@@ -6,6 +6,7 @@ export * from './references.ts'
 
 export * as nip04 from './nip04.ts'
 export * as nip05 from './nip05.ts'
+export * as nip07 from './nip07.ts'
 export * as nip10 from './nip10.ts'
 export * as nip11 from './nip11.ts'
 export * as nip13 from './nip13.ts'

--- a/jsr.json
+++ b/jsr.json
@@ -16,6 +16,7 @@
     "./nip04": "./nip04.ts",
     "./nip05": "./nip05.ts",
     "./nip06": "./nip06.ts",
+    "./nip07": "./nip07.ts",
     "./nip10": "./nip10.ts",
     "./nip11": "./nip11.ts",
     "./nip13": "./nip13.ts",

--- a/nip07.ts
+++ b/nip07.ts
@@ -1,9 +1,9 @@
-import { EventTemplate, VerifiedEvent } from './core.ts'
+import { EventTemplate, NostrEvent } from './core.ts'
 import { RelayRecord } from './index.ts'
 
 export interface Nip07 {
   getPublicKey(): Promise<string>
-  signEvent(event: EventTemplate): Promise<VerifiedEvent>
+  signEvent(event: EventTemplate): Promise<NostrEvent>
   getRelays(): Promise<RelayRecord>
   nip04?: {
     encrypt(pubkey: string, plaintext: string): Promise<string>

--- a/nip07.ts
+++ b/nip07.ts
@@ -1,15 +1,15 @@
-import { EventTemplate, NostrEvent } from './core.ts'
-import { RelayMap } from './index.ts'
+import { EventTemplate, VerifiedEvent } from './core.ts'
+import { RelayRecord } from './index.ts'
 
 export interface Nip07 {
   getPublicKey(): Promise<string>
-  signEvent(event: EventTemplate): Promise<NostrEvent>
-  getRelays(): Promise<RelayMap>
-  nip04: {
+  signEvent(event: EventTemplate): Promise<VerifiedEvent>
+  getRelays(): Promise<RelayRecord>
+  nip04?: {
     encrypt(pubkey: string, plaintext: string): Promise<string>
     ecrypt(pubkey: string, ciphertext: string): Promise<string>
   }
-  nip44: {
+  nip44?: {
     encrypt(pubkey: string, plaintext: string): Promise<string>
     decrypt(pubkey: string, ciphertext: string): Promise<string>
   }

--- a/nip07.ts
+++ b/nip07.ts
@@ -1,0 +1,16 @@
+import { EventTemplate, NostrEvent } from './core.ts'
+import { RelayMap } from './index.ts'
+
+export interface Nip07 {
+  getPublicKey(): Promise<string>
+  signEvent(event: EventTemplate): Promise<NostrEvent>
+  getRelays(): Promise<RelayMap>
+  nip04: {
+    encrypt(pubkey: string, plaintext: string): Promise<string>
+    ecrypt(pubkey: string, ciphertext: string): Promise<string>
+  }
+  nip44: {
+    encrypt(pubkey: string, plaintext: string): Promise<string>
+    decrypt(pubkey: string, ciphertext: string): Promise<string>
+  }
+}

--- a/nip46.ts
+++ b/nip46.ts
@@ -7,7 +7,7 @@ import { NIP05_REGEX } from './nip05.ts'
 import { SimplePool } from './pool.ts'
 import { Handlerinformation, NostrConnect } from './kinds.ts'
 import { hexToBytes } from '@noble/hashes/utils'
-import { RelayMap } from './index.ts'
+import { RelayRecord } from './index.ts'
 
 var _fetch: any
 
@@ -217,7 +217,7 @@ export class BunkerSigner {
   /**
    * Calls the "get_relays" method on the bunker.
    */
-  async getRelays(): Promise<RelayMap> {
+  async getRelays(): Promise<RelayRecord> {
     return JSON.parse(await this.sendRequest('get_relays', []))
   }
 

--- a/nip46.ts
+++ b/nip46.ts
@@ -7,6 +7,7 @@ import { NIP05_REGEX } from './nip05.ts'
 import { SimplePool } from './pool.ts'
 import { Handlerinformation, NostrConnect } from './kinds.ts'
 import { hexToBytes } from '@noble/hashes/utils'
+import { RelayMap } from './index.ts'
 
 var _fetch: any
 
@@ -216,7 +217,7 @@ export class BunkerSigner {
   /**
    * Calls the "get_relays" method on the bunker.
    */
-  async getRelays(): Promise<{ [relay: string]: { read: boolean; write: boolean } }> {
+  async getRelays(): Promise<RelayMap> {
     return JSON.parse(await this.sendRequest('get_relays', []))
   }
 

--- a/package.json
+++ b/package.json
@@ -85,6 +85,9 @@
       "require": "./lib/cjs/nip06.js",
       "types": "./lib/types/nip06.d.ts"
     },
+    "./nip07": {
+      "types": "./lib/types/nip07.d.ts"
+    },
     "./nip10": {
       "import": "./lib/esm/nip10.js",
       "require": "./lib/cjs/nip10.js",

--- a/relay.ts
+++ b/relay.ts
@@ -20,6 +20,6 @@ export class Relay extends AbstractRelay {
   }
 }
 
-export type RelayMap = { [relay: string]: { read: boolean; write: boolean } };
+export type RelayRecord = Record<string, { read: boolean; write: boolean }>;
 
 export * from './abstract-relay.ts'

--- a/relay.ts
+++ b/relay.ts
@@ -20,4 +20,6 @@ export class Relay extends AbstractRelay {
   }
 }
 
+export type RelayMap = { [relay: string]: { read: boolean; write: boolean } };
+
 export * from './abstract-relay.ts'


### PR DESCRIPTION
This pull request includes:
- typescript interface for nip07;
- centralized nip46 and nip07 relay map into a named type and export it;
- include docs of how to include the nip07 type for browser environment;

I haven't finished testing it yet and it's not ready, but I opened the pull request to advance the code review