### PR TITLE
getFilterLimit: empty tags return 0

### DIFF
--- a/filter.test.ts
+++ b/filter.test.ts
@@ -222,5 +222,9 @@ describe('Filter', () => {
     test('should return Infinity for empty filters', () => {
       expect(getFilterLimit({})).toEqual(Infinity)
     })
+
+    test('empty tags return 0', () => {
+      expect(getFilterLimit({ '#p': [] })).toEqual(0)
+    })
   })
 })

--- a/filter.ts
+++ b/filter.ts
@@ -78,6 +78,10 @@ export function getFilterLimit(filter: Filter): number {
   if (filter.kinds && !filter.kinds.length) return 0
   if (filter.authors && !filter.authors.length) return 0
 
+  for (const [key, value] of Object.entries(filter)) {
+    if (key[0] === '#' && Array.isArray(value) && !value.length) return 0
+  }
+
   return Math.min(
     Math.max(0, filter.limit ?? Infinity),
     filter.ids?.length ?? Infinity,


### PR DESCRIPTION
Filters with empty tag queries have an intrinsic limit of `0`.