### PR TITLE
fix Content-Type bug in NIP-96 uploadFile

### DIFF
--- a/nip96.ts
+++ b/nip96.ts
@@ -359,7 +359,6 @@ export async function uploadFile(
     method: 'POST',
     headers: {
       Authorization: nip98AuthorizationHeader,
-      'Content-Type': 'multipart/form-data',
     },
     body: formData,
   })


### PR DESCRIPTION
## Why

The NIP-96 uploadFile has a bug. This PR fixes it.

When using `fetch` API along with `FormData`, specifying `Content-Type` will cause error. It is because if we specify  `Content-Type: multipart/form-data`,  the browser will send it as is without considering "boundary".

> Warning: When using FormData to submit POST requests using XMLHttpRequest or the Fetch API with the multipart/form-data content type (e.g. when uploading files and blobs to the server), do not explicitly set the Content-Type header on the request. Doing so will prevent the browser from being able to set the Content-Type header with the boundary expression it will use to delimit form fields in the request body.
> https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest_API/Using_FormData_Objects#sending_files_using_a_formdata_object

The browser will detect `Content-Type` from `body` and append `boundary=...` appropriately. We don't need to specify `Content-Type`.

## References

- https://stackoverflow.com/questions/39280438/fetch-missing-boundary-in-multipart-form-data-post
- https://zenn.dev/kariya_mitsuru/articles/25c9aeb27059e7
- https://nostr.com/note1xyk98avw48l3zm60fj8vesnuduujh3mxhs0px7l05dvlcpjjzdzswvas3x
- https://nostr.com/note1tz3v2d83ayk3uqa62nj64gefdpxu9vxr9jjd502fxelnmap9fqdq0tsghf