### PR TITLE
support fallback tag of NIP-94

### DIFF
--- a/nip94.test.ts
+++ b/nip94.test.ts
@@ -21,6 +21,7 @@ describe('generateEventTemplate', () => {
       image: 'https://example.com/image.jpg',
       summary: 'Lorem ipsum',
       alt: 'Image alt text',
+      fallback: ['https://fallback1.example.com/image.jpg', 'https://fallback2.example.com/image.jpg'],
     }
 
     const expectedEventTemplate: EventTemplate = {
@@ -40,6 +41,8 @@ describe('generateEventTemplate', () => {
         ['image', 'https://example.com/image.jpg'],
         ['summary', 'Lorem ipsum'],
         ['alt', 'Image alt text'],
+        ['fallback', 'https://fallback1.example.com/image.jpg'],
+        ['fallback', 'https://fallback2.example.com/image.jpg'],
       ],
     }
 
@@ -71,6 +74,7 @@ describe('validateEvent', () => {
           ['image', 'https://example.com/image.jpg'],
           ['summary', 'Lorem ipsum'],
           ['alt', 'Image alt text'],
+          ['fallback', 'https://fallback.example.com/image.jpg'],
         ],
       },
       sk,
@@ -100,6 +104,7 @@ describe('validateEvent', () => {
           ['image', 'https://example.com/image.jpg'],
           ['summary', 'Lorem ipsum'],
           ['alt', 'Image alt text'],
+          ['fallback', 'https://fallback.example.com/image.jpg'],
         ],
       },
       sk,
@@ -129,6 +134,7 @@ describe('validateEvent', () => {
           ['image', 'https://example.com/image.jpg'],
           ['summary', 'Lorem ipsum'],
           ['alt', 'Image alt text'],
+          ['fallback', 'https://fallback.example.com/image.jpg'],
         ],
       },
       sk,
@@ -158,6 +164,7 @@ describe('validateEvent', () => {
           ['image', 'https://example.com/image.jpg'],
           ['summary', 'Lorem ipsum'],
           ['alt', 'Image alt text'],
+          ['fallback', 'https://fallback.example.com/image.jpg'],
         ],
       },
       sk,
@@ -181,6 +188,7 @@ describe('validateEvent', () => {
           ['image', 'https://example.com/image.jpg'],
           ['summary', 'Lorem ipsum'],
           ['alt', 'Image alt text'],
+          ['fallback', 'https://fallback.example.com/image.jpg'],
         ],
       },
       sk,
@@ -204,6 +212,7 @@ describe('validateEvent', () => {
           ['image', 'https://example.com/image.jpg'],
           ['summary', 'Lorem ipsum'],
           ['alt', 'Image alt text'],
+          ['fallback', 'https://fallback.example.com/image.jpg'],
         ],
       },
       sk,
@@ -227,6 +236,7 @@ describe('validateEvent', () => {
           ['image', 'https://example.com/image.jpg'],
           ['summary', 'Lorem ipsum'],
           ['alt', 'Image alt text'],
+          ['fallback', 'https://fallback.example.com/image.jpg'],
         ],
       },
       sk,
@@ -259,6 +269,7 @@ describe('validateEvent', () => {
           ['image', 'https://example.com/image.jpg'],
           ['summary', 'Lorem ipsum'],
           ['alt', 'Image alt text'],
+          ['fallback', 'https://fallback.example.com/image.jpg'],
         ],
       },
       sk,
@@ -288,6 +299,7 @@ describe('validateEvent', () => {
           ['image', 'https://example.com/image.jpg'],
           ['summary', 'Lorem ipsum'],
           ['alt', 'Image alt text'],
+          ['fallback', 'https://fallback.example.com/image.jpg'],
         ],
       },
       sk,
@@ -319,6 +331,8 @@ describe('parseEvent', () => {
           ['image', 'https://example.com/image.jpg'],
           ['summary', 'Lorem ipsum'],
           ['alt', 'Image alt text'],
+          ['fallback', 'https://fallback1.example.com/image.jpg'],
+          ['fallback', 'https://fallback2.example.com/image.jpg'],
         ],
       },
       sk,
@@ -340,6 +354,7 @@ describe('parseEvent', () => {
       image: 'https://example.com/image.jpg',
       summary: 'Lorem ipsum',
       alt: 'Image alt text',
+      fallback: ['https://fallback1.example.com/image.jpg', 'https://fallback2.example.com/image.jpg'],
     })
   })
 
@@ -364,6 +379,7 @@ describe('parseEvent', () => {
           ['image', 'https://example.com/image.jpg'],
           ['summary', 'Lorem ipsum'],
           ['alt', 'Image alt text'],
+          ['fallback', 'https://fallback.example.com/image.jpg'],
         ],
       },
       sk,

--- a/nip94.ts
+++ b/nip94.ts
@@ -75,6 +75,11 @@ export type FileMetadataObject = {
    * Optional: A description for accessibility, providing context or a brief description of the file.
    */
   alt?: string
+
+  /**
+   * Optional: fallback URLs in case url fails.
+   */
+  fallback?: string[]
 }
 
 /**
@@ -104,6 +109,7 @@ export function generateEventTemplate(fileMetadata: FileMetadataObject): EventTe
   if (fileMetadata.image) eventTemplate.tags.push(['image', fileMetadata.image])
   if (fileMetadata.summary) eventTemplate.tags.push(['summary', fileMetadata.summary])
   if (fileMetadata.alt) eventTemplate.tags.push(['alt', fileMetadata.alt])
+  if (fileMetadata.fallback) fileMetadata.fallback.forEach(url => eventTemplate.tags.push(['fallback', url]))
 
   return eventTemplate
 }
@@ -193,6 +199,10 @@ export function parseEvent(event: Event): FileMetadataObject {
         break
       case 'alt':
         fileMetadata.alt = value
+        break
+      case 'fallback':
+        fileMetadata.fallback ??= []
+        fileMetadata.fallback.push(value)
         break
     }
   }


### PR DESCRIPTION
[NIP-94](https://github.com/nostr-protocol/nips/blob/master/94.md) defines `fallback` tag ([2c016b0](https://github.com/nostr-protocol/nips/commit/2c016b0659a8f29ad2420a4cd844a2dca4956407)). This PR add support for `fallback` tag.

I am not sure that this is really and widely used.
