### PR TITLE
Making AbstractSimplesPool more extensible

### DIFF
--- a/abstract-pool.ts
+++ b/abstract-pool.ts
@@ -23,7 +23,7 @@ export type SubscribeManyParams = Omit<SubscriptionParams, 'onclose' | 'id'> & {
 }
 
 export class AbstractSimplePool {
-  private relays = new Map<string, AbstractRelay>()
+  protected relays = new Map<string, AbstractRelay>()
   public seenOn: Map<string, Set<AbstractRelay>> = new Map()
   public trackRelays: boolean = false
 


### PR DESCRIPTION
I wanna extends AbstractSimplesPool to create and test other complementary implementations for my software, It will be so bad to change this to `protected`? Please 🙏