### PR TITLE
methods for abstract pool

### DIFF
--- a/abstract-pool.ts
+++ b/abstract-pool.ts
@@ -211,8 +211,7 @@ export class AbstractSimplePool {
 
   listConnectionStatus(): Map<string, boolean> {
     const map = new Map<string, boolean>()
-    this.relays
-      .forEach((relay, url) => map.set(url, relay.connected))
+    this.relays.forEach((relay, url) => map.set(url, relay.connected))
 
     return map
   }

--- a/abstract-pool.ts
+++ b/abstract-pool.ts
@@ -208,4 +208,17 @@ export class AbstractSimplePool {
       return r.publish(event)
     })
   }
+
+  listConnectionStatus(): Map<string, boolean> {
+    const map = new Map<string, boolean>()
+    this.relays
+      .forEach((relay, url) => map.set(url, relay.connected))
+
+    return map
+  }
+
+  destroy(): void {
+    this.relays.forEach(conn => conn.close())
+    this.relays = new Map()
+  }
 }


### PR DESCRIPTION
I am suggesting the inclusion of two methods within the abstract pool.

`listConnectionStatus` to return a snapshot of all relays connection status in the pool.
`destroy` method, to close all connections in the pool (close method requires the relay list).

I have included then in my project abstract pool, but I wondered if you could consider these features as useful and interesting to be centralized in this library.