### PR TITLE
Fix NIP-96 uploads

### DIFF
--- a/nip96.ts
+++ b/nip96.ts
@@ -359,7 +359,6 @@ export async function uploadFile(
     method: 'POST',
     headers: {
       Authorization: nip98AuthorizationHeader,
-      'Content-Type': 'multipart/form-data',
     },
     body: formData,
   })


### PR DESCRIPTION
Surprising one liner change (and boy was it hard for me to track down) but the `Content-Type` header should not be explicitly set.

See https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest_API/Using_FormData_Objects#sending_files_using_a_formdata_object

> Warning: **When using FormData to submit POST requests** using [XMLHttpRequest](https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest) or the [Fetch API](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API) with the multipart/form-data content type (e.g. when uploading files and blobs to the server), **do not explicitly set the [Content-Type](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Type) header** on the request. Doing so will prevent the browser from being able to set the Content-Type header with the boundary expression it will use to delimit form fields in the request body.