### PR TITLE
added support for zapping replaceable events

### DIFF
--- a/nip57.ts
+++ b/nip57.ts
@@ -2,6 +2,7 @@ import { bech32 } from '@scure/base'
 
 import { validateEvent, verifyEvent, type Event, type EventTemplate } from './pure.ts'
 import { utf8Decoder } from './utils.ts'
+import { isReplaceableKind, isAddressableKind } from './kinds.ts'
 
 var _fetch: any
 
@@ -73,11 +74,11 @@ export function makeZapRequest({
   }
   if (event && typeof event === 'object') {
     // replacable event
-    if ((10000 <= event.kind  && event.kind < 20000) || event.kind  == 0 || event.kind  == 3){
+    if (isReplaceableKind(event.kind)) {
       const a = ["a", `${event.kind}:${event.pubkey}:`]
       zr.tags.push(a)
-    // parameterized replacable event
-    }else if (30000 <= event.kind && event.kind < 40000){
+    // addressable event
+    } else if (isAddressableKind(event.kind)) {
       let d = event.tags.find(([t, v]) => t === 'd' && v)
       if (!d) throw new Error('d tag not found or is empty')
       const a = ["a", `${event.kind}:${event.pubkey}:${d[1]}`]

--- a/nip57.ts
+++ b/nip57.ts
@@ -72,7 +72,6 @@ export function makeZapRequest({
     zr.tags.push(['e', event])
   }
   if (event && typeof event === 'object') {
-    zr.tags.push(['e', event.id])
     // replacable event
     if ((10000 <= event.kind  && event.kind < 20000) || event.kind  == 0 || event.kind  == 3){
       const a = ["a", `${event.kind}:${event.pubkey}:`]

--- a/nip57.ts
+++ b/nip57.ts
@@ -49,7 +49,7 @@ export function makeZapRequest({
   comment = '',
 }: {
   profile: string
-  event: string | null
+  event: string | Event | null
   amount: number
   comment: string
   relays: string[]
@@ -68,8 +68,22 @@ export function makeZapRequest({
     ],
   }
 
-  if (event) {
+  if (event && typeof event === 'string') {
     zr.tags.push(['e', event])
+  }
+  if (event && typeof event === 'object') {
+    zr.tags.push(['e', event.id])
+    // replacable event
+    if ((10000 <= event.kind  && event.kind < 20000) || event.kind  == 0 || event.kind  == 3){
+      const a = ["a", `${event.kind}:${event.pubkey}`]
+      zr.tags.push(a)
+    // parameterized replacable event
+    }else if (30000 <= event.kind && event.kind < 40000){
+      let d = event.tags.find(([t, v]) => t === 'd' && v)
+      if (!d) throw new Error('d tag not found or is empty')
+      const a = ["a", `${event.kind}:${event.pubkey}:${d[1]}`]
+      zr.tags.push(a)
+    }
   }
 
   return zr

--- a/nip57.ts
+++ b/nip57.ts
@@ -75,13 +75,13 @@ export function makeZapRequest({
   if (event && typeof event === 'object') {
     // replacable event
     if (isReplaceableKind(event.kind)) {
-      const a = ["a", `${event.kind}:${event.pubkey}:`]
+      const a = ['a', `${event.kind}:${event.pubkey}:`]
       zr.tags.push(a)
     // addressable event
     } else if (isAddressableKind(event.kind)) {
       let d = event.tags.find(([t, v]) => t === 'd' && v)
       if (!d) throw new Error('d tag not found or is empty')
-      const a = ["a", `${event.kind}:${event.pubkey}:${d[1]}`]
+      const a = ['a', `${event.kind}:${event.pubkey}:${d[1]}`]
       zr.tags.push(a)
     }
   }

--- a/nip57.ts
+++ b/nip57.ts
@@ -75,7 +75,7 @@ export function makeZapRequest({
     zr.tags.push(['e', event.id])
     // replacable event
     if ((10000 <= event.kind  && event.kind < 20000) || event.kind  == 0 || event.kind  == 3){
-      const a = ["a", `${event.kind}:${event.pubkey}`]
+      const a = ["a", `${event.kind}:${event.pubkey}:`]
       zr.tags.push(a)
     // parameterized replacable event
     }else if (30000 <= event.kind && event.kind < 40000){


### PR DESCRIPTION
fixes #291 

I tried to keep it backwards compatible by allowing the event id and the event object. 