### PR TITLE
authorization should not be in the form data

### DIFF
--- a/nip96.ts
+++ b/nip96.ts
@@ -340,9 +340,6 @@ export async function uploadFile(
   // Create FormData object
   const formData = new FormData()
 
-  // Append the authorization header to HTML Form Data
-  formData.append('Authorization', nip98AuthorizationHeader)
-
   // Append optional fields to FormData
   optionalFormDataFields &&
     Object.entries(optionalFormDataFields).forEach(([key, value]) => {


### PR DESCRIPTION
this uploadFile function does not work with nostr.build because `Authorization` is not a [valid form field](https://github.com/nostr-protocol/nips/blob/master/96.md#upload.). nostr.build returns a 400 error.