### PR TITLE
nip44Decrypt sends nip44_decrypt request

### DIFF
--- a/nip46.ts
+++ b/nip46.ts
@@ -254,7 +254,7 @@ export class BunkerSigner {
   }
 
   async nip44Decrypt(thirdPartyPubkey: string, ciphertext: string): Promise<string> {
-    return await this.sendRequest('nip44_encrypt', [thirdPartyPubkey, ciphertext])
+    return await this.sendRequest('nip44_decrypt', [thirdPartyPubkey, ciphertext])
   }
 }
 


### PR DESCRIPTION
This PR addresses a typo where the `nip44Decrypt` function call would send the `nip44_encrypt` request instead of the `nip44_decrypt` request.

This change provides a fix for the typo