### PR TITLE
nip06: return Uint8 instead of string

### DIFF
--- a/nip06.test.ts
+++ b/nip06.test.ts
@@ -5,38 +5,39 @@ import {
   extendedKeysFromSeedWords,
   accountFromExtendedKey,
 } from './nip06.ts'
+import { hexToBytes } from '@noble/hashes/utils'
 
 test('generate private key from a mnemonic', async () => {
   const mnemonic = 'zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo wrong'
   const privateKey = privateKeyFromSeedWords(mnemonic)
-  expect(privateKey).toEqual('c26cf31d8ba425b555ca27d00ca71b5008004f2f662470f8c8131822ec129fe2')
+  expect(privateKey).toEqual(hexToBytes('c26cf31d8ba425b555ca27d00ca71b5008004f2f662470f8c8131822ec129fe2'))
 })
 
 test('generate private key for account 1 from a mnemonic', async () => {
   const mnemonic = 'zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo wrong'
   const privateKey = privateKeyFromSeedWords(mnemonic, undefined, 1)
-  expect(privateKey).toEqual('b5fc7f229de3fb5c189063e3b3fc6c921d8f4366cff5bd31c6f063493665eb2b')
+  expect(privateKey).toEqual(hexToBytes('b5fc7f229de3fb5c189063e3b3fc6c921d8f4366cff5bd31c6f063493665eb2b'))
 })
 
 test('generate private key from a mnemonic and passphrase', async () => {
   const mnemonic = 'zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo wrong'
   const passphrase = '123'
   const privateKey = privateKeyFromSeedWords(mnemonic, passphrase)
-  expect(privateKey).toEqual('55a22b8203273d0aaf24c22c8fbe99608e70c524b17265641074281c8b978ae4')
+  expect(privateKey).toEqual(hexToBytes('55a22b8203273d0aaf24c22c8fbe99608e70c524b17265641074281c8b978ae4'))
 })
 
 test('generate private key for account 1 from a mnemonic and passphrase', async () => {
   const mnemonic = 'zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo wrong'
   const passphrase = '123'
   const privateKey = privateKeyFromSeedWords(mnemonic, passphrase, 1)
-  expect(privateKey).toEqual('2e0f7bd9e3c3ebcdff1a90fb49c913477e7c055eba1a415d571b6a8c714c7135')
+  expect(privateKey).toEqual(hexToBytes('2e0f7bd9e3c3ebcdff1a90fb49c913477e7c055eba1a415d571b6a8c714c7135'))
 })
 
 test('generate private and public key for account 1 from a mnemonic and passphrase', async () => {
   const mnemonic = 'zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo wrong'
   const passphrase = '123'
   const { privateKey, publicKey } = accountFromSeedWords(mnemonic, passphrase, 1)
-  expect(privateKey).toEqual('2e0f7bd9e3c3ebcdff1a90fb49c913477e7c055eba1a415d571b6a8c714c7135')
+  expect(privateKey).toEqual(hexToBytes('2e0f7bd9e3c3ebcdff1a90fb49c913477e7c055eba1a415d571b6a8c714c7135'))
   expect(publicKey).toEqual('13f55f4f01576570ea342eb7d2b611f9dc78f8dc601aeb512011e4e73b90cf0a')
 })
 
@@ -63,7 +64,7 @@ test('generate account from extended private key', () => {
     'xprv9z78fizET65qsCaRr1MSutTSGk1fcKfSt1sBqmuWShtkjRJJ4WCKcSnha6EmgNzFSsyom3MWtydHyPtJtSLZQUtictVQtM2vkPcguh6TQCH'
   const { privateKey, publicKey } = accountFromExtendedKey(xprv)
 
-  expect(privateKey).toBe('5f29af3b9676180290e77a4efad265c4c2ff28a5302461f73597fda26bb25731')
+  expect(privateKey).toBe(hexToBytes('5f29af3b9676180290e77a4efad265c4c2ff28a5302461f73597fda26bb25731'))
   expect(publicKey).toBe('e8bcf3823669444d0b49ad45d65088635d9fd8500a75b5f20b59abefa56a144f')
 })
 

--- a/nip06.test.ts
+++ b/nip06.test.ts
@@ -64,7 +64,7 @@ test('generate account from extended private key', () => {
     'xprv9z78fizET65qsCaRr1MSutTSGk1fcKfSt1sBqmuWShtkjRJJ4WCKcSnha6EmgNzFSsyom3MWtydHyPtJtSLZQUtictVQtM2vkPcguh6TQCH'
   const { privateKey, publicKey } = accountFromExtendedKey(xprv)
 
-  expect(privateKey).toBe(hexToBytes('5f29af3b9676180290e77a4efad265c4c2ff28a5302461f73597fda26bb25731'))
+  expect(privateKey).toEqual(hexToBytes('5f29af3b9676180290e77a4efad265c4c2ff28a5302461f73597fda26bb25731'))
   expect(publicKey).toBe('e8bcf3823669444d0b49ad45d65088635d9fd8500a75b5f20b59abefa56a144f')
 })
 

--- a/nip06.ts
+++ b/nip06.ts
@@ -5,11 +5,11 @@ import { HDKey } from '@scure/bip32'
 
 const DERIVATION_PATH = `m/44'/1237'`
 
-export function privateKeyFromSeedWords(mnemonic: string, passphrase?: string, accountIndex = 0): string {
+export function privateKeyFromSeedWords(mnemonic: string, passphrase?: string, accountIndex = 0): Uint8Array {
   let root = HDKey.fromMasterSeed(mnemonicToSeedSync(mnemonic, passphrase))
   let privateKey = root.derive(`${DERIVATION_PATH}/${accountIndex}'/0/0`).privateKey
   if (!privateKey) throw new Error('could not derive private key')
-  return bytesToHex(privateKey)
+  return privateKey
 }
 
 export function accountFromSeedWords(
@@ -17,14 +17,14 @@ export function accountFromSeedWords(
   passphrase?: string,
   accountIndex = 0,
 ): {
-  privateKey: string
+  privateKey: Uint8Array
   publicKey: string
 } {
   const root = HDKey.fromMasterSeed(mnemonicToSeedSync(mnemonic, passphrase))
   const seed = root.derive(`${DERIVATION_PATH}/${accountIndex}'/0/0`)
-  const privateKey = bytesToHex(seed.privateKey!)
   const publicKey = bytesToHex(seed.publicKey!.slice(1))
-  if (!privateKey && !publicKey) {
+  const privateKey = seed.privateKey
+  if (!privateKey || !publicKey) {
     throw new Error('could not derive key pair')
   }
   return { privateKey, publicKey }
@@ -50,7 +50,7 @@ export function accountFromExtendedKey(
   base58key: string,
   accountIndex = 0,
 ): {
-  privateKey?: string
+  privateKey?: Uint8Array
   publicKey: string
 } {
   let extendedKey = HDKey.fromExtendedKey(base58key)
@@ -59,7 +59,7 @@ export function accountFromExtendedKey(
   let publicKey = bytesToHex(child.publicKey!.slice(1))
   if (!publicKey) throw new Error('could not derive public key')
   if (version === 'xprv') {
-    let privateKey = bytesToHex(child.privateKey!)
+    let privateKey = child.privateKey!
     if (!privateKey) throw new Error('could not derive private key')
     return { privateKey, publicKey }
   }


### PR DESCRIPTION
This PR adjusts the nip06 implementation so that it returns privatekeys as bytes to align with the rest of the lib