### PR TITLE
Fix fetch to work in the edge and node environments, cleanup type issues

### DIFF
--- a/nip05.ts
+++ b/nip05.ts
@@ -12,20 +12,24 @@ export type Nip05 = `${string}@${string}`
 export const NIP05_REGEX = /^(?:([\w.+-]+)@)?([\w_-]+(\.[\w_-]+)+)$/
 export const isNip05 = (value?: string | null): value is Nip05 => NIP05_REGEX.test(value || '')
 
-var _fetch: any
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+let _fetch: any
 
 try {
   _fetch = fetch
-} catch {}
+} catch (_) {null}
 
-export function useFetchImplementation(fetchImplementation: any) {
+export function useFetchImplementation(fetchImplementation: unknown) {
   _fetch = fetchImplementation
 }
 
 export async function searchDomain(domain: string, query = ''): Promise<{ [name: string]: string }> {
   try {
     const url = `https://${domain}/.well-known/nostr.json?name=${query}`
-    const res = await _fetch(url, { redirect: 'error' })
+    const res = await _fetch(url, { redirect: 'manual' })
+    if (res.status !== 200) {
+      throw Error("Wrong response code")
+    }
     const json = await res.json()
     return json.names
   } catch (_) {
@@ -37,20 +41,24 @@ export async function queryProfile(fullname: string): Promise<ProfilePointer | n
   const match = fullname.match(NIP05_REGEX)
   if (!match) return null
 
-  const [_, name = '_', domain] = match
+  const [, name = '_', domain] = match
 
   try {
     const url = `https://${domain}/.well-known/nostr.json?name=${name}`
-    const res = await (await _fetch(url, { redirect: 'error' })).json()
+    const res = await _fetch(url, { redirect: 'manual' })
+    if (res.status !== 200) {
+      throw Error("Wrong response code")
+    }
+    const json = await res.json()
 
-    let pubkey = res.names[name]
-    return pubkey ? { pubkey, relays: res.relays?.[pubkey] } : null
+    const pubkey = json.names[name]
+    return pubkey ? { pubkey, relays: json.relays?.[pubkey] } : null
   } catch (_e) {
     return null
   }
 }
 
 export async function isValid(pubkey: string, nip05: Nip05): Promise<boolean> {
-  let res = await queryProfile(nip05)
+  const res = await queryProfile(nip05)
   return res ? res.pubkey === pubkey : false
 }


### PR DESCRIPTION
Ran into issues with the nip05 profile fetching silently failing in the edge environment, here are the fixes with minor cleanup. Behavior is identical to the previouse one, and redirect will cause failure since non-200 code is returned.
- Fix "TypeError: Invalid redirect value, must be one of "follow" or "manual" ("error" won't be implemented since it does not make sense at the edge; use "manual" and check the response status code)." that is thrown when trying to use fetch in the edge environment  (e.g., workers)
- Cleanup types and variable definitions.