### PR TITLE
make publish() timeout.

### DIFF
--- a/abstract-relay.ts
+++ b/abstract-relay.ts
@@ -24,6 +24,7 @@ export class AbstractRelay {
 
   public baseEoseTimeout: number = 4400
   public connectionTimeout: number = 4400
+  public publishTimeout: number = 4400
   public openSubs: Map<string, Subscription> = new Map()
   private connectionTimeoutHandle: ReturnType<typeof setTimeout> | undefined
 
@@ -198,9 +199,11 @@ export class AbstractRelay {
           const ok: boolean = data[2]
           const reason: string = data[3]
           const ep = this.openEventPublishes.get(id) as EventPublishResolver
-          if (ok) ep.resolve(reason)
-          else ep.reject(new Error(reason))
-          this.openEventPublishes.delete(id)
+          if (ep) {
+            if (ok) ep.resolve(reason)
+            else ep.reject(new Error(reason))
+            this.openEventPublishes.delete(id)
+          }
           return
         }
         case 'CLOSED': {
@@ -248,6 +251,13 @@ export class AbstractRelay {
       this.openEventPublishes.set(event.id, { resolve, reject })
     })
     this.send('["EVENT",' + JSON.stringify(event) + ']')
+    setTimeout(() => {
+      const ep = this.openEventPublishes.get(event.id) as EventPublishResolver
+      if (ep) {
+        ep.reject(new Error('publish timed out'))
+        this.openEventPublishes.delete(event.id)
+      }
+    }, this.publishTimeout)
     return ret
   }
 


### PR DESCRIPTION
I don't know why, but there are relays (e.g wss://relay.nostr.bg) that does not send an `OK` message in response to an `EVENT` message. In that case we wait forever for it and the promise returned by `publish()` is never resolve/reject.

This PR adds a timeout and solves that problem.