### PR TITLE
nip05: use stub to test queryProfile().

### DIFF
--- a/nip05.test.ts
+++ b/nip05.test.ts
@@ -1,5 +1,4 @@
 import { test, expect } from 'bun:test'
-import fetch from 'node-fetch'
 
 import { useFetchImplementation, queryProfile, NIP05_REGEX, isNip05 } from './nip05.ts'
 
@@ -16,7 +15,27 @@ test('validate NIP05_REGEX', () => {
 })
 
 test('fetch nip05 profiles', async () => {
-  useFetchImplementation(fetch)
+  const fetchStub = async (url: string) => ({
+    status: 200,
+    async json() {
+      return {
+        'https://compile-error.net/.well-known/nostr.json?name=_': {
+          names: { _: '2c7cc62a697ea3a7826521f3fd34f0cb273693cbe5e9310f35449f43622a5cdc' },
+        },
+        'https://fiatjaf.com/.well-known/nostr.json?name=_': {
+          names: { _: '3bf0c63fcb93463407af97a5e5ee64fa883d107ef9e558472c4eb9aaaefa459d' },
+          relays: {
+            '3bf0c63fcb93463407af97a5e5ee64fa883d107ef9e558472c4eb9aaaefa459d': [
+              'wss://pyramid.fiatjaf.com',
+              'wss://nos.lol',
+            ],
+          },
+        },
+      }[url]
+    },
+  })
+
+  useFetchImplementation(fetchStub)
 
   let p2 = await queryProfile('compile-error.net')
   expect(p2!.pubkey).toEqual('2c7cc62a697ea3a7826521f3fd34f0cb273693cbe5e9310f35449f43622a5cdc')


### PR DESCRIPTION
Avoid test failures due to changes `/.well-known/nostr.json` in the real world.