### PR TITLE
nip19: remove noteEncode().

### DIFF
--- a/nip19.ts
+++ b/nip19.ts
@@ -173,10 +173,6 @@ export function npubEncode(hex: string): NPub {
   return encodeBytes('npub', hexToBytes(hex))
 }
 
-export function noteEncode(hex: string): Note {
-  return encodeBytes('note', hexToBytes(hex))
-}
-
 function encodeBech32<Prefix extends string>(prefix: Prefix, data: Uint8Array): `${Prefix}1${string}` {
   let words = bech32.toWords(data)
   return bech32.encode(prefix, words, Bech32MaxSize) as `${Prefix}1${string}`


### PR DESCRIPTION
In response to the discussion in #456, I only removed the encoding.