### PR TITLE
remove unnecessary id from Omit keys.

### DIFF
--- a/abstract-pool.ts
+++ b/abstract-pool.ts
@@ -16,7 +16,7 @@ export type SubCloser = { close: () => void }
 
 export type AbstractPoolConstructorOptions = AbstractRelayConstructorOptions & {}
 
-export type SubscribeManyParams = Omit<SubscriptionParams, 'onclose' | 'id'> & {
+export type SubscribeManyParams = Omit<SubscriptionParams, 'onclose'> & {
   maxWait?: number
   onclose?: (reasons: string[]) => void
   id?: string


### PR DESCRIPTION
`id` was removed from `SubscriptionParams` in 804403f.