### PR TITLE
Case insensitive tag matching

### DIFF
--- a/filter.ts
+++ b/filter.ts
@@ -26,8 +26,8 @@ export function matchFilter(filter: Filter, event: Event): boolean {
   for (let f in filter) {
     if (f[0] === '#') {
       let tagName = f.slice(1)
-      let values = filter[`#${tagName}`]
-      if (values && !event.tags.find(([t, v]) => t === f.slice(1) && values!.indexOf(v) !== -1)) return false
+      let values = filter[`#${tagName}`]?.map(v => v.toLowerCase())
+      if (values && !event.tags.find(([t, v]) => t === tagName && values!.indexOf(v.toLowerCase()) !== -1)) return false
     }
   }
 


### PR DESCRIPTION
My issue #466 wasn't related to duplicate events as I thought but due to matchFilter being case sensitive.

Would a skipFilter option be useful?  In my case I'm using a khatru relay.  When I send a tag filter for `bitcoin` it's returning events where the t tag matches and if Bitcoin is in the content.  Not sure if that's normal behavior but it's kinda what I want.   These subscription events don't make it to onevent because they don't pass matchFilter.

```javascript
    const sub = relay.subscribe([filter], {
      skipMatchFilter: true
    });
```