### PR TITLE
Clean up nip96 upload validation and make it less strict

### DIFF
--- a/nip55.test.ts
+++ b/nip55.test.ts
@@ -2,7 +2,7 @@ import { test, expect } from 'bun:test'
 import * as nip55 from './nip55.js'
 
 // Function to parse the NostrSigner URI
-function parseNostrSignerUri(uri) {
+function parseNostrSignerUri(uri: string) {
   const [base, query] = uri.split('?')
   const basePart = base.replace('nostrsigner:', '')
 


### PR DESCRIPTION
The old version of the code was swallowing slightly more descriptive errors and re-throwing as json parse errors. It was also validating for a non-empty message, which was breaking nostrcheck.me uploads.