### PR TITLE
Generic repost event for addressable events

### DIFF
--- a/nip18.test.ts
+++ b/nip18.test.ts
@@ -113,8 +113,8 @@ describe('GenericRepost', () => {
     expect(event.tags).toEqual([
       ['e', repostedEvent.id, relayUrl],
       ['p', repostedEvent.pubkey],
-      ['a', '30009:6af0f9de588f2c53cedcba26c5e2402e0d0aa64ec7b47c9f8d97b5bc562bab5f:badge-id' ],
-      ['relay-url', 'https://relay.example.com' ]
+      ['a', '30009:6af0f9de588f2c53cedcba26c5e2402e0d0aa64ec7b47c9f8d97b5bc562bab5f:badge-id'],
+      ['relay-url', 'https://relay.example.com'],
     ])
     expect(event.content).toEqual(JSON.stringify(repostedEvent))
     expect(event.created_at).toEqual(template.created_at)

--- a/nip18.test.ts
+++ b/nip18.test.ts
@@ -114,6 +114,7 @@ describe('GenericRepost', () => {
       ['e', repostedEvent.id, relayUrl],
       ['p', repostedEvent.pubkey],
       ['a', '30009:6af0f9de588f2c53cedcba26c5e2402e0d0aa64ec7b47c9f8d97b5bc562bab5f:badge-id'],
+      ['k', '30009'],
       ['relay-url', 'https://relay.example.com'],
     ])
     expect(event.content).toEqual(JSON.stringify(repostedEvent))
@@ -129,14 +130,6 @@ describe('GenericRepost', () => {
     const repostedEventFromContent = getRepostedEvent(event)
 
     expect(repostedEventFromContent).toEqual(repostedEvent)
-  })
-
-  test('throws an error if repost something different from addressable or short text', () => {
-    const template = { created_at: 1617932115 }
-    const reposting = finishRepostEvent(template, repostedEvent, relayUrl, privateKey)
-    expect(() => {
-      finishRepostEvent(template, reposting, relayUrl, privateKey)
-    }).toThrow()
   })
 
   test('throws an error if d tag is missing for generic repost', () => {

--- a/nip18.test.ts
+++ b/nip18.test.ts
@@ -113,7 +113,7 @@ describe('GenericRepost', () => {
     expect(event.tags).toEqual([
       ['e', repostedEvent.id, relayUrl],
       ['p', repostedEvent.pubkey],
-      ['k', '30009']
+      ['k', '30009'],
     ])
     expect(event.content).toEqual(JSON.stringify(repostedEvent))
     expect(event.created_at).toEqual(template.created_at)

--- a/nip18.test.ts
+++ b/nip18.test.ts
@@ -131,27 +131,6 @@ describe('GenericRepost', () => {
 
     expect(repostedEventFromContent).toEqual(repostedEvent)
   })
-
-  test('throws an error if d tag is missing for generic repost', () => {
-    const missingIdentifierTemplate: EventTemplate = {
-      content: '',
-      created_at: 1617932114,
-      kind: BadgeDefinitionKind,
-      tags: [
-        ['name', 'Badge Name'],
-        ['description', 'Badge Description'],
-        ['image', 'https://example.com/badge.png', '1024x1024'],
-        ['thumb', 'https://example.com/thumb.png', '100x100'],
-        ['thumb', 'https://example.com/thumb2.png', '200x200'],
-      ],
-    }
-
-    const missingIdentifierEvent = finalizeEvent(missingIdentifierTemplate, privateKey)
-    const template = { created_at: 1617932115 }
-    expect(() => {
-      finishRepostEvent(template, missingIdentifierEvent, relayUrl, privateKey)
-    }).toThrow()
-  })
 })
 
 describe('getRepostedEventPointer', () => {

--- a/nip18.test.ts
+++ b/nip18.test.ts
@@ -1,7 +1,7 @@
 import { describe, test, expect } from 'bun:test'
 import { hexToBytes } from '@noble/hashes/utils'
-import { finalizeEvent, getPublicKey } from './pure.ts'
-import { Repost, ShortTextNote } from './kinds.ts'
+import { EventTemplate, finalizeEvent, getPublicKey } from './pure.ts'
+import { GenericRepost, Repost, ShortTextNote, BadgeDefinition as BadgeDefinitionKind } from './kinds.ts'
 import { finishRepostEvent, getRepostedEventPointer, getRepostedEvent } from './nip18.ts'
 import { buildEvent } from './test-helpers.ts'
 
@@ -83,6 +83,81 @@ describe('finishRepostEvent + getRepostedEventPointer + getRepostedEvent', () =>
     const repostedEventFromContent = getRepostedEvent(event)
 
     expect(repostedEventFromContent).toBeUndefined()
+  })
+})
+
+describe('GenericRepost', () => {
+  const privateKey = hexToBytes('d217c1ff2f8a65c3e3a1740db3b9f58b8c848bb45e26d00ed4714e4a0f4ceecf')
+  const publicKey = getPublicKey(privateKey)
+
+  const eventTemplate: EventTemplate = {
+    content: '',
+    created_at: 1617932114,
+    kind: BadgeDefinitionKind,
+    tags: [
+      ['d', 'badge-id'],
+      ['name', 'Badge Name'],
+      ['description', 'Badge Description'],
+      ['image', 'https://example.com/badge.png', '1024x1024'],
+      ['thumb', 'https://example.com/thumb.png', '100x100'],
+      ['thumb', 'https://example.com/thumb2.png', '200x200'],
+    ],
+  }
+
+  const repostedEvent = finalizeEvent(eventTemplate, privateKey)
+  test('should create a generic reposted event', () => {
+    const template = { created_at: 1617932115 }
+    const event = finishRepostEvent(template, repostedEvent, relayUrl, privateKey)
+
+    expect(event.kind).toEqual(GenericRepost)
+    expect(event.tags).toEqual([
+      ['e', repostedEvent.id, relayUrl],
+      ['p', repostedEvent.pubkey],
+      ['a', '30009:6af0f9de588f2c53cedcba26c5e2402e0d0aa64ec7b47c9f8d97b5bc562bab5f:badge-id' ],
+      ['relay-url', 'https://relay.example.com' ]
+    ])
+    expect(event.content).toEqual(JSON.stringify(repostedEvent))
+    expect(event.created_at).toEqual(template.created_at)
+    expect(event.pubkey).toEqual(publicKey)
+
+    const repostedEventPointer = getRepostedEventPointer(event)
+
+    expect(repostedEventPointer!.id).toEqual(repostedEvent.id)
+    expect(repostedEventPointer!.author).toEqual(repostedEvent.pubkey)
+    expect(repostedEventPointer!.relays).toEqual([relayUrl])
+
+    const repostedEventFromContent = getRepostedEvent(event)
+
+    expect(repostedEventFromContent).toEqual(repostedEvent)
+  })
+
+  test('throws an error if repost something different from addressable or short text', () => {
+    const template = { created_at: 1617932115 }
+    const reposting = finishRepostEvent(template, repostedEvent, relayUrl, privateKey)
+    expect(() => {
+      finishRepostEvent(template, reposting, relayUrl, privateKey)
+    }).toThrow()
+  })
+
+  test('throws an error if d tag is missing for generic repost', () => {
+    const missingIdentifierTemplate: EventTemplate = {
+      content: '',
+      created_at: 1617932114,
+      kind: BadgeDefinitionKind,
+      tags: [
+        ['name', 'Badge Name'],
+        ['description', 'Badge Description'],
+        ['image', 'https://example.com/badge.png', '1024x1024'],
+        ['thumb', 'https://example.com/thumb.png', '100x100'],
+        ['thumb', 'https://example.com/thumb2.png', '200x200'],
+      ],
+    }
+
+    const missingIdentifierEvent = finalizeEvent(missingIdentifierTemplate, privateKey)
+    const template = { created_at: 1617932115 }
+    expect(() => {
+      finishRepostEvent(template, missingIdentifierEvent, relayUrl, privateKey)
+    }).toThrow()
   })
 })
 

--- a/nip18.test.ts
+++ b/nip18.test.ts
@@ -113,9 +113,7 @@ describe('GenericRepost', () => {
     expect(event.tags).toEqual([
       ['e', repostedEvent.id, relayUrl],
       ['p', repostedEvent.pubkey],
-      ['a', '30009:6af0f9de588f2c53cedcba26c5e2402e0d0aa64ec7b47c9f8d97b5bc562bab5f:badge-id'],
-      ['k', '30009'],
-      ['relay-url', 'https://relay.example.com'],
+      ['k', '30009']
     ])
     expect(event.content).toEqual(JSON.stringify(repostedEvent))
     expect(event.created_at).toEqual(template.created_at)

--- a/nip18.ts
+++ b/nip18.ts
@@ -30,17 +30,8 @@ export function finishRepostEvent(
   if (reposted.kind === ShortTextNote) {
     kind = Repost
   } else {
-    let d = reposted.tags.find(([t, v]) => t === 'd' && v)
-    let address = `${reposted.kind}:${reposted.pubkey}`
-    if (d && d.length) {
-      address += `:${d[1]}`
-    }
-
-    const addressTag = ['a', address]
     kind = GenericRepost
-    tags.push(addressTag)
     tags.push(['k', String(reposted.kind)])
-    tags.push(['relay-url', relayUrl])
   }
 
   return finalizeEvent(

--- a/nip18.ts
+++ b/nip18.ts
@@ -29,16 +29,15 @@ export function finishRepostEvent(
   const tags = [...(t.tags ?? []), ['e', reposted.id, relayUrl], ['p', reposted.pubkey]]
   if (reposted.kind === ShortTextNote) {
     kind = Repost
-  } else if (isAddressableKind(reposted.kind)) {
+  } else {
     let d = reposted.tags.find(([t, v]) => t === 'd' && v)
     if (!d) throw new Error('d tag not found or is empty')
     const address = ['a', `${reposted.kind}:${reposted.pubkey}:${d[1]}`]
 
     kind = GenericRepost
     tags.push(address)
+    tags.push(['k', String(reposted.kind)])
     tags.push(['relay-url', relayUrl])
-  } else {
-    throw new Error(`repost kind ${reposted.kind} is not supported`)
   }
 
   return finalizeEvent(

--- a/nip18.ts
+++ b/nip18.ts
@@ -1,6 +1,6 @@
-import { Event, finalizeEvent, verifyEvent } from './pure.ts'
-import { GenericRepost, isAddressableKind, Repost, ShortTextNote } from './kinds.ts'
+import { GenericRepost, Repost, ShortTextNote } from './kinds.ts'
 import { EventPointer } from './nip19.ts'
+import { Event, finalizeEvent, verifyEvent } from './pure.ts'
 
 export type RepostEventTemplate = {
   /**
@@ -31,11 +31,14 @@ export function finishRepostEvent(
     kind = Repost
   } else {
     let d = reposted.tags.find(([t, v]) => t === 'd' && v)
-    if (!d) throw new Error('d tag not found or is empty')
-    const address = ['a', `${reposted.kind}:${reposted.pubkey}:${d[1]}`]
+    let address = `${reposted.kind}:${reposted.pubkey}`
+    if (d && d.length) {
+      address += `:${d[1]}`
+    }
 
+    const addressTag = ['a', address]
     kind = GenericRepost
-    tags.push(address)
+    tags.push(addressTag)
     tags.push(['k', String(reposted.kind)])
     tags.push(['relay-url', relayUrl])
   }

--- a/nip18.ts
+++ b/nip18.ts
@@ -53,7 +53,7 @@ export function finishRepostEvent(
 }
 
 export function getRepostedEventPointer(event: Event): undefined | EventPointer {
-  if (![ Repost, GenericRepost ].includes(event.kind)) {
+  if (![Repost, GenericRepost].includes(event.kind)) {
     return undefined
   }
 


### PR DESCRIPTION
This pull request include backwards compatible implementation of NIP18 update for generic repost support for addressable events.
Includes throwing exceptions for invalid events and validating these exceptions in unit tests.

Please, validate if this implementation satisfies the needs for https://github.com/nbd-wtf/nostr-tools/issues/476.