### PR TITLE
Typescript type inference for 'decode' function for nip19 is not working fully

### DIFF
--- a/nip19.test.ts
+++ b/nip19.test.ts
@@ -1,17 +1,15 @@
-import { test, expect, describe } from 'bun:test'
-import { generateSecretKey, getPublicKey } from './pure.ts'
+import { describe, expect, test } from 'bun:test'
 import {
   decode,
   naddrEncode,
+  neventEncode,
+  NostrTypeGuard,
   nprofileEncode,
   npubEncode,
   nsecEncode,
-  neventEncode,
-  type AddressPointer,
-  type ProfilePointer,
-  EventPointer,
-  NostrTypeGuard,
+  type ProfilePointer
 } from './nip19.ts'
+import { generateSecretKey, getPublicKey } from './pure.ts'
 
 test('encode and decode nsec', () => {
   let sk = generateSecretKey()
@@ -38,7 +36,7 @@ test('encode and decode nprofile', () => {
   expect(nprofile).toMatch(/nprofile1\w+/)
   let { type, data } = decode(nprofile)
   expect(type).toEqual('nprofile')
-  const pointer = data as ProfilePointer
+  const pointer = data
   expect(pointer.pubkey).toEqual(pk)
   expect(pointer.relays).toContain(relays[0])
   expect(pointer.relays).toContain(relays[1])
@@ -67,7 +65,7 @@ test('encode and decode naddr', () => {
   expect(naddr).toMatch(/naddr1\w+/)
   let { type, data } = decode(naddr)
   expect(type).toEqual('naddr')
-  const pointer = data as AddressPointer
+  const pointer = data
   expect(pointer.pubkey).toEqual(pk)
   expect(pointer.relays).toContain(relays[0])
   expect(pointer.relays).toContain(relays[1])
@@ -86,7 +84,7 @@ test('encode and decode nevent', () => {
   expect(nevent).toMatch(/nevent1\w+/)
   let { type, data } = decode(nevent)
   expect(type).toEqual('nevent')
-  const pointer = data as EventPointer
+  const pointer = data
   expect(pointer.id).toEqual(pk)
   expect(pointer.relays).toContain(relays[0])
   expect(pointer.kind).toEqual(30023)
@@ -103,7 +101,7 @@ test('encode and decode nevent with kind 0', () => {
   expect(nevent).toMatch(/nevent1\w+/)
   let { type, data } = decode(nevent)
   expect(type).toEqual('nevent')
-  const pointer = data as EventPointer
+  const pointer = data
   expect(pointer.id).toEqual(pk)
   expect(pointer.relays).toContain(relays[0])
   expect(pointer.kind).toEqual(0)
@@ -121,7 +119,7 @@ test('encode and decode naddr with empty "d"', () => {
   expect(naddr).toMatch(/naddr\w+/)
   let { type, data } = decode(naddr)
   expect(type).toEqual('naddr')
-  const pointer = data as AddressPointer
+  const pointer = data
   expect(pointer.identifier).toEqual('')
   expect(pointer.relays).toContain(relays[0])
   expect(pointer.kind).toEqual(3)
@@ -133,7 +131,7 @@ test('decode naddr from habla.news', () => {
     'naddr1qq98yetxv4ex2mnrv4esygrl54h466tz4v0re4pyuavvxqptsejl0vxcmnhfl60z3rth2xkpjspsgqqqw4rsf34vl5',
   )
   expect(type).toEqual('naddr')
-  const pointer = data as AddressPointer
+  const pointer = data
   expect(pointer.pubkey).toEqual('7fa56f5d6962ab1e3cd424e758c3002b8665f7b0d8dcee9fe9e288d7751ac194')
   expect(pointer.kind).toEqual(30023)
   expect(pointer.identifier).toEqual('references')
@@ -145,7 +143,7 @@ test('decode naddr from go-nostr with different TLV ordering', () => {
   )
 
   expect(type).toEqual('naddr')
-  const pointer = data as AddressPointer
+  const pointer = data
   expect(pointer.pubkey).toEqual('3bf0c63fcb93463407af97a5e5ee64fa883d107ef9e558472c4eb9aaaefa459d')
   expect(pointer.relays).toContain('wss://relay.nostr.example.mydomain.example.com')
   expect(pointer.relays).toContain('wss://nostr.banana.com')

--- a/nip19.ts
+++ b/nip19.ts
@@ -80,6 +80,12 @@ export type DecodeResult = {
 }[keyof Prefixes]
 
 export function decode<Prefix extends keyof Prefixes>(nip19: `${Prefix}1${string}`): DecodeValue<Prefix>
+export function decode(nip19: NProfile): DecodeValue<'nprofile'>
+export function decode(nip19: NEvent): DecodeValue<'nevent'>
+export function decode(nip19: NAddr): DecodeValue<'naddr'>
+export function decode(nip19: NSec): DecodeValue<'nsec'>
+export function decode(nip19: NPub): DecodeValue<'npub'>
+export function decode(nip19: Note): DecodeValue<'note'>
 export function decode(nip19: string): DecodeResult
 export function decode(nip19: string): DecodeResult {
   let { prefix, words } = bech32.decode(nip19, Bech32MaxSize)

--- a/nip29.ts
+++ b/nip29.ts
@@ -2,7 +2,7 @@ import { AbstractSimplePool } from './abstract-pool.ts'
 import { Subscription } from './abstract-relay.ts'
 import type { Event, EventTemplate } from './core.ts'
 import { fetchRelayInformation, RelayInformation } from './nip11.ts'
-import { AddressPointer, decode } from './nip19.ts'
+import { AddressPointer, decode, NostrTypeGuard } from './nip19.ts'
 import { normalizeURL } from './utils.ts'
 
 /**
@@ -518,11 +518,11 @@ export async function loadGroupFromCode(pool: AbstractSimplePool, code: string):
  * @returns A GroupReference object if the code is valid, otherwise null.
  */
 export function parseGroupCode(code: string): null | GroupReference {
-  if (code.startsWith('naddr1')) {
+  if (NostrTypeGuard.isNAddr(code)) {
     try {
       let { data } = decode(code)
 
-      let { relays, identifier } = data as AddressPointer
+      let { relays, identifier } = data
       if (!relays || relays.length === 0) return null
 
       let host = relays![0]


### PR DESCRIPTION
Although there appears to be something implemented in this regard, 'decode' function is not returning specific type for specific parameters signature.
In this request I'm including alternative specific signatures if the first generic signature fails, this will solve complexity of extra validation after decoding or forcing cast using 'as' keyword.

To validate this implementation I have remove the keyword 'as' for cast into unit tests, so the unit tests validates the returning type also. 'As' keyword will force the return to the type dev wish, but if the parameter change it'll keep returning the forced type and will show no type error.

Currently (one signature, multiple return):
![image](https://github.com/user-attachments/assets/e1b74e70-a399-4247-ab60-cc661e558dd8)

With the changes of this pull request (fixed):
![image](https://github.com/user-attachments/assets/7f4899ec-2f54-4bf2-8215-52f80e06c48b)
