### PR TITLE
Fix JSON syntax of jsr.json

### DIFF
--- a/jsr.json
+++ b/jsr.json
@@ -44,7 +44,7 @@
     "./nip99": "./nip99.ts",
     "./nipb7": "./nipb7.ts",
     "./fakejson": "./fakejson.ts",
-    "./utils": "./utils.ts"
+    "./utils": "./utils.ts",
     "./signer": "./signer.ts"
   }
 }


### PR DESCRIPTION
This PR fixes the syntax error in `jsr.json`.