### PR TITLE
Fix Relay subscribe() method generates malformed JSON when filters are empty

### DIFF
--- a/abstract-relay.ts
+++ b/abstract-relay.ts
@@ -370,7 +370,7 @@ export class Subscription {
   }
 
   public fire() {
-    this.relay.send('["REQ","' + this.id + '",' + JSON.stringify(this.filters).substring(1))
+    this.relay.send(JSON.stringify(['REQ', this.id, ...this.filters]))
 
     // only now we start counting the eoseTimeout
     this.eoseTimeoutHandle = setTimeout(this.receivedEose.bind(this), this.eoseTimeout)


### PR DESCRIPTION
### Description

When `subscribe()` is passed an empty filters array as the first argument, the message sent to the relay contains a trailing comma causing JSON parsing on the relay side to fail.

### Minimal reproduction

```TypeScript
import { WebSocketServer } from "ws"; 
import { Relay } from "nostr-tools";

const server = new WebSocketServer({ port: 8092 });

server.on('connection', function connection(ws) {
    ws.on('error', console.error);

    ws.on('message', (data, isBinary) => {
        const text = isBinary ? Buffer.from(data).toString() : (data).toString();
        console.log(text);

        try {
            const message = JSON.parse(text);
            console.log(message);
        } catch {
            console.log('malformed JSON');
        }
    });
});

const client = new Relay('ws://localhost:8092');
client.connect();
client.subscribe([], {});
```
### Expected output

```
["REQ","sub:1"]
[ 'REQ', 'sub:1' ]
```

### Actual output

```
["REQ","sub:1",]
malformed JSON
```