### PR TITLE
Get pingpong working in the browser with dummy REQ

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,14 @@ import WebSocket from 'ws'
 useWebSocketImplementation(WebSocket)
 ```
 
+You can enable regular pings of connected relays with the `enablePing` option. This will set up a heartbeat that closes the websocket if it doesn't receive a response in time. Some platforms don't report websocket disconnections due to network issues, and enabling this can increase reliability.
+
+```js
+import { SimplePool } from 'nostr-tools/pool'
+
+const pool = new SimplePool({ enablePing: true })
+```
+
 ### Parsing references (mentions) from a content based on NIP-27
 
 ```js

--- a/abstract-pool.ts
+++ b/abstract-pool.ts
@@ -32,6 +32,7 @@ export class AbstractSimplePool {
   public trackRelays: boolean = false
 
   public verifyEvent: Nostr['verifyEvent']
+  public enablePing: boolean | undefined
   public trustedRelayURLs: Set<string> = new Set()
 
   private _WebSocket?: typeof WebSocket
@@ -39,6 +40,7 @@ export class AbstractSimplePool {
   constructor(opts: AbstractPoolConstructorOptions) {
     this.verifyEvent = opts.verifyEvent
     this._WebSocket = opts.websocketImplementation
+    this.enablePing = opts.enablePing
   }
 
   async ensureRelay(url: string, params?: { connectionTimeout?: number }): Promise<AbstractRelay> {
@@ -49,6 +51,7 @@ export class AbstractSimplePool {
       relay = new AbstractRelay(url, {
         verifyEvent: this.trustedRelayURLs.has(url) ? alwaysTrue : this.verifyEvent,
         websocketImplementation: this._WebSocket,
+        enablePing: this.enablePing,
       })
       relay.onclose = () => {
         this.relays.delete(url)

--- a/abstract-relay.ts
+++ b/abstract-relay.ts
@@ -149,7 +149,7 @@ export class AbstractRelay {
   private async waitForPingPong() {
     return new Promise((res, err) => {
       // listen for pong
-      (this.ws && this.ws.on && this.ws.on('pong', () => res(true))) || err("ws can't listen for pong")
+      ;(this.ws && this.ws.on && this.ws.on('pong', () => res(true))) || err("ws can't listen for pong")
       // send a ping
       this.ws && this.ws.ping && this.ws.ping()
     })
@@ -177,7 +177,7 @@ export class AbstractRelay {
       // wait for either a ping-pong reply or a timeout
       const result = await Promise.any([
         // browsers don't have ping so use a dummy req
-        (this.ws && this.ws.ping && this.ws.on) ? this.waitForPingPong() : this.waitForDummyReq(),
+        this.ws && this.ws.ping && this.ws.on ? this.waitForPingPong() : this.waitForDummyReq(),
         new Promise(res => setTimeout(() => res(false), this.pingTimeout)),
       ])
       if (result) {

--- a/abstract-relay.ts
+++ b/abstract-relay.ts
@@ -146,9 +146,11 @@ export class AbstractRelay {
     return this.connectionPromise
   }
 
-  private async receivePong() {
+  private async waitForPingPong() {
     return new Promise((res, err) => {
-      ;(this.ws && this.ws.on && this.ws.on('pong', () => res(true))) || err("ws can't listen for pong")
+      (this.ws && this.ws.on && this.ws.on('pong', () => res(true))) || err("ws can't listen for pong")
+      // send a ping
+      this.ws && this.ws.ping && this.ws.ping()
     })
   }
 
@@ -157,11 +159,9 @@ export class AbstractRelay {
   private async pingpong() {
     // if the websocket is connected
     if (this.ws?.readyState === 1) {
-      // send a ping
-      this.ws && this.ws.ping && this.ws.ping()
-      // wait for either a pong or a timeout
+      // wait for either a ping-pong reply or a timeout
       const result = await Promise.any([
-        this.receivePong(),
+        this.waitForPingPong(),
         new Promise(res => setTimeout(() => res(false), this.pingTimeout)),
       ])
       if (result) {

--- a/abstract-relay.ts
+++ b/abstract-relay.ts
@@ -169,7 +169,10 @@ export class AbstractRelay {
         setTimeout(() => this.pingpong(), this.pingFrequency)
       } else {
         // pingpong closing socket
-        this.ws.close()
+        this.closeAllSubscriptions('pingpong timed out')
+        this._connected = false
+        this.ws?.close()
+        this.onclose?.()
       }
     }
   }

--- a/abstract-relay.ts
+++ b/abstract-relay.ts
@@ -35,8 +35,8 @@ export class AbstractRelay {
   public baseEoseTimeout: number = 4400
   public connectionTimeout: number = 4400
   public publishTimeout: number = 4400
-  public pingFrequency: number = 45000
-  public pingTimeout: number = 45000
+  public pingFrequency: number = 20000
+  public pingTimeout: number = 20000
   public openSubs: Map<string, Subscription> = new Map()
   public enablePing: boolean | undefined
   private connectionTimeoutHandle: ReturnType<typeof setTimeout> | undefined

--- a/nip19.test.ts
+++ b/nip19.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from 'bun:test'
+// prettier-ignore
 import {
   decode,
   naddrEncode,

--- a/pool.ts
+++ b/pool.ts
@@ -14,8 +14,8 @@ export function useWebSocketImplementation(websocketImplementation: any) {
 }
 
 export class SimplePool extends AbstractSimplePool {
-  constructor() {
-    super({ verifyEvent, websocketImplementation: _WebSocket })
+  constructor(options?: { enablePing?: boolean }) {
+    super({ verifyEvent, websocketImplementation: _WebSocket, ...options })
   }
 }
 


### PR DESCRIPTION
- Add `enablePing` option - nothing happens without it.
- Add fake `REQ` to ping relays in the browser.
- Set default ping and timeout to 45s.

See comments on #495 #498 for history.