### PR TITLE
relay: ensure onclose callback is triggered

### DIFF
--- a/abstract-relay.ts
+++ b/abstract-relay.ts
@@ -121,23 +121,19 @@ export class AbstractRelay {
       this.ws.onerror = ev => {
         clearTimeout(this.connectionTimeoutHandle)
         reject((ev as any).message || 'websocket error')
-        if (this._connected) {
-          this._connected = false
-          this.connectionPromise = undefined
-          this.onclose?.()
-          this.closeAllSubscriptions('relay connection errored')
-        }
+        this._connected = false
+        this.connectionPromise = undefined
+        this.onclose?.()
+        this.closeAllSubscriptions('relay connection errored')
       }
 
       this.ws.onclose = ev => {
         clearTimeout(this.connectionTimeoutHandle)
         reject((ev as any).message || 'websocket closed')
-        if (this._connected) {
-          this._connected = false
-          this.connectionPromise = undefined
-          this.onclose?.()
-          this.closeAllSubscriptions('relay connection closed')
-        }
+        this._connected = false
+        this.connectionPromise = undefined
+        this.onclose?.()
+        this.closeAllSubscriptions('relay connection closed')
       }
 
       this.ws.onmessage = this._onmessage.bind(this)
@@ -187,8 +183,8 @@ export class AbstractRelay {
         // pingpong closing socket
         this.closeAllSubscriptions('pingpong timed out')
         this._connected = false
-        this.ws?.close()
         this.onclose?.()
+        this.ws?.close()
       }
     }
   }
@@ -378,8 +374,8 @@ export class AbstractRelay {
   public close() {
     this.closeAllSubscriptions('relay connection closed by us')
     this._connected = false
-    this.ws?.close()
     this.onclose?.()
+    this.ws?.close()
   }
 
   // this is the function assigned to this.ws.onmessage


### PR DESCRIPTION
1. When `ws.onerror` or `ws.onclose` events are triggered before a successful connection (while `this._connected` is still `false`), the `this.onclose?.()` callback was not being called. This prevented the relay from being removed from the pool, making it impossible to reconnect via `ensureRelay`.

2. Potential error in close sequence: The `this.onclose?.()` callback was called after `this.ws?.close()`, which could potentially throw an error and prevent the `this.onclose?.()` callback from executing.
 