### PR TITLE
chore: Bump version and document NIP-46 usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,7 +191,7 @@ const localSecretKey = generateSecretKey()
 
 ### Method 1: Using a Bunker URI (`bunker://`)
 
-This is the bunker-initiated flow. Your client receives a `bunker://` string or a NIP-05 identifier from the user. You use `BunkerSigner.fromBunker()` to create an instance, which returns immediately. You must then explicitly call `await bunker.connect()` to establish the connection with the bunker.
+This is the bunker-initiated flow. Your client receives a `bunker://` string or a NIP-05 identifier from the user. You use `BunkerSigner.fromBunker()` to create an instance, which returns immediately. For the **initial connection** with a new bunker, you must explicitly call `await bunker.connect()` to establish the connection and receive authorization.
 
 ```js
 import { BunkerSigner, parseBunkerInput } from '@nostr/tools/nip46'
@@ -221,6 +221,7 @@ const event = await bunker.signEvent({
 await signer.close()
 pool.close([])
 ```
+> **Note on Reconnecting:** Once a connection has been successfully established and the `BunkerPointer` is stored, you do **not** need to call `await bunker.connect()` on subsequent sessions. 
 
 ### Method 2: Using a Client-generated URI (`nostrconnect://`)
 
@@ -260,6 +261,7 @@ const event = await signer.signEvent({
 await signer.close()
 pool.close([])
 ```
+> **Note on Persistence:** This method is ideal for the initial sign-in. To allow users to stay logged in across sessions, you should store the connection details and use `Method 1` for subsequent reconnections. 
 
 ### Parsing thread from any note based on NIP-10
 

--- a/jsr.json
+++ b/jsr.json
@@ -1,6 +1,6 @@
 {
   "name": "@nostr/tools",
-  "version": "2.16.2",
+  "version": "2.17.0",
   "exports": {
     ".": "./index.ts",
     "./core": "./core.ts",

--- a/nip46.ts
+++ b/nip46.ts
@@ -97,7 +97,7 @@ export type ParsedNostrConnectURI = {
     name?: string
     url?: string
     image?: string
-  };
+  }
   originalString: string
 }
 
@@ -185,7 +185,6 @@ export function parseNostrConnectURI(uri: string): ParsedNostrConnectURI {
   }
 }
 
-
 export type BunkerSignerParams = {
   pool?: AbstractSimplePool
   onauth?: (url: string) => void
@@ -236,7 +235,7 @@ export class BunkerSigner implements Signer {
   public static fromBunker(
     clientSecretKey: Uint8Array,
     bp: BunkerPointer,
-    params: BunkerSignerParams = {}
+    params: BunkerSignerParams = {},
   ): BunkerSigner {
     if (bp.relays.length === 0) {
       throw new Error('No relays specified for this bunker')
@@ -304,11 +303,10 @@ export class BunkerSigner implements Signer {
             reject(new Error('Subscription closed before connection was established.'))
           },
           maxWait,
-        }
+        },
       )
     })
   }
-
 
   private setupSubscription(params: BunkerSignerParams) {
     const listeners = this.listeners

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "type": "module",
   "name": "nostr-tools",
-  "version": "2.16.2",
+  "version": "2.17.0",
   "description": "Tools for making a Nostr client.",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Bumps the package version to prepare for a new release.

Also updates the README.md to include a  guide for reusing NIP-46 connections, clarifying the intended workflow between the `fromURI` and `fromBunker` factory methods.
