### PR TITLE
adds `just watch` command for rebuilds

### DIFF
--- a/justfile
+++ b/justfile
@@ -5,6 +5,9 @@ build:
   bun run build.js
   tsc
 
+watch:
+  watchexec -e ts just build
+
 test:
   bun test --timeout 20000
 


### PR DESCRIPTION
it does require [watchexec](https://github.com/watchexec/watchexec) and is not smart about rebuilding.