### PR TITLE
Improvements to enablePing() & tests

### DIFF
--- a/pool.test.ts
+++ b/pool.test.ts
@@ -59,16 +59,24 @@ test('same with double subs', async () => {
   let priv = generateSecretKey()
   let pub = getPublicKey(priv)
 
-  pool.subscribeMany(relayURLs, { authors: [pub] }, {
-    onevent(event) {
-      received.push(event)
+  pool.subscribeMany(
+    relayURLs,
+    { authors: [pub] },
+    {
+      onevent(event) {
+        received.push(event)
+      },
     },
-  })
-  pool.subscribeMany(relayURLs, { authors: [pub] }, {
-    onevent(event) {
-      received.push(event)
+  )
+  pool.subscribeMany(
+    relayURLs,
+    { authors: [pub] },
+    {
+      onevent(event) {
+        received.push(event)
+      },
     },
-  })
+  )
 
   let received: Event[] = []
 
@@ -172,12 +180,16 @@ test('query a bunch of events and cancel on eose', async () => {
   let events = new Set<string>()
 
   await new Promise<void>(resolve => {
-    pool.subscribeManyEose(relayURLs, { kinds: [0, 1, 2, 3, 4, 5, 6], limit: 40 }, {
-      onevent(event) {
-        events.add(event.id)
+    pool.subscribeManyEose(
+      relayURLs,
+      { kinds: [0, 1, 2, 3, 4, 5, 6], limit: 40 },
+      {
+        onevent(event) {
+          events.add(event.id)
+        },
+        onclose: resolve as any,
       },
-      onclose: resolve as any,
-    })
+    )
   })
 
   expect(events.size).toBeGreaterThan(50)

--- a/relay.ts
+++ b/relay.ts
@@ -14,12 +14,12 @@ export function useWebSocketImplementation(websocketImplementation: any) {
 }
 
 export class Relay extends AbstractRelay {
-  constructor(url: string) {
-    super(url, { verifyEvent, websocketImplementation: _WebSocket })
+  constructor(url: string, options?: { enablePing?: boolean }) {
+    super(url, { verifyEvent, websocketImplementation: _WebSocket, ...options })
   }
 
-  static async connect(url: string): Promise<Relay> {
-    const relay = new Relay(url)
+  static async connect(url: string, options?: { enablePing?: boolean }): Promise<Relay> {
+    const relay = new Relay(url, options)
     await relay.connect()
     return relay
   }

--- a/test-helpers.ts
+++ b/test-helpers.ts
@@ -26,6 +26,7 @@ export class MockRelay {
   public url: string
   public secretKeys: Uint8Array[]
   public preloadedEvents: Event[]
+  public unresponsive: boolean = false
 
   constructor(url?: string | undefined) {
     serial++
@@ -48,6 +49,7 @@ export class MockRelay {
       let subs: { [subId: string]: { conn: any; filters: Filter[] } } = {}
 
       conn.on('message', (message: string) => {
+        if (this.unresponsive) return
         const data = JSON.parse(message)
 
         switch (data[0]) {


### PR DESCRIPTION
- Fix to allow `enablePing` to be passed to direct `Relay` instantiation.
- Flag to make `MockRelay` behave like an unresponsive relay.
- Added relay and pool tests for `enablePing`.