### PR TITLE
Reconnect with exponential backoff flag: `enableReconnect`

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,14 +153,14 @@ import { SimplePool } from 'nostr-tools/pool'
 const pool = new SimplePool({ enableReconnect: true })
 ```
 
-On Node.js, it is recommended to also use `enablePing: true` to ensure network disconnections are properly detected.
+Using both `enablePing: true` and `enableReconnect: true` is recommended as it will improve the reliability and timeliness of the reconnection (at the expense of slighly higher bandwidth due to the ping messages).
 
 ```js
 // on Node.js
 const pool = new SimplePool({ enablePing: true, enableReconnect: true })
 ```
 
-The `enableReconnect` option can also be a callback function that receives the current subscription filters and returns a new set of filters. This is useful if you want to modify the subscription on reconnect, for example, to update the `since` parameter to fetch only new events.
+The `enableReconnect` option can also be a callback function which will receive the current subscription filters and should return a new set of filters. This is useful if you want to modify the subscription on reconnect, for example, to update the `since` parameter to fetch only new events.
 
 ```js
 const pool = new SimplePool({

--- a/README.md
+++ b/README.md
@@ -133,13 +133,17 @@ import WebSocket from 'ws'
 useWebSocketImplementation(WebSocket)
 ```
 
-You can enable regular pings of connected relays with the `enablePing` option. This will set up a heartbeat that closes the websocket if it doesn't receive a response in time. Some platforms don't report websocket disconnections due to network issues, and enabling this can increase reliability.
+#### enablePing
+
+You can enable regular pings of connected relays with the `enablePing` option. This will set up a heartbeat that closes the websocket if it doesn't receive a response in time. Some platforms, like Node.js, don't report websocket disconnections due to network issues, and enabling this can increase the reliability of the `onclose` event.
 
 ```js
 import { SimplePool } from 'nostr-tools/pool'
 
 const pool = new SimplePool({ enablePing: true })
 ```
+
+#### enableReconnect
 
 You can also enable automatic reconnection with the `enableReconnect` option. This will make the pool try to reconnect to relays with an exponential backoff delay if the connection is lost unexpectedly.
 

--- a/README.md
+++ b/README.md
@@ -141,6 +141,32 @@ import { SimplePool } from 'nostr-tools/pool'
 const pool = new SimplePool({ enablePing: true })
 ```
 
+You can also enable automatic reconnection with the `enableReconnect` option. This will make the pool try to reconnect to relays with an exponential backoff delay if the connection is lost unexpectedly.
+
+```js
+import { SimplePool } from 'nostr-tools/pool'
+
+const pool = new SimplePool({ enableReconnect: true })
+```
+
+On Node.js, it is recommended to also use `enablePing: true` to ensure network disconnections are properly detected.
+
+```js
+// on Node.js
+const pool = new SimplePool({ enablePing: true, enableReconnect: true })
+```
+
+The `enableReconnect` option can also be a callback function that receives the current subscription filters and returns a new set of filters. This is useful if you want to modify the subscription on reconnect, for example, to update the `since` parameter to fetch only new events.
+
+```js
+const pool = new SimplePool({
+  enableReconnect: (filters) => {
+    const newSince = Math.floor(Date.now() / 1000)
+    return filters.map(filter => ({ ...filter, since: newSince }))
+  }
+})
+```
+
 ### Parsing references (mentions) from a content based on NIP-27
 
 ```js

--- a/abstract-pool.ts
+++ b/abstract-pool.ts
@@ -57,7 +57,9 @@ export class AbstractSimplePool {
         enableReconnect: this.enableReconnect,
       })
       relay.onclose = () => {
-        this.relays.delete(url)
+        if (relay && !relay.enableReconnect) {
+          this.relays.delete(url)
+        }
       }
       if (params?.connectionTimeout) relay.connectionTimeout = params.connectionTimeout
       this.relays.set(url, relay)

--- a/abstract-pool.ts
+++ b/abstract-pool.ts
@@ -33,6 +33,7 @@ export class AbstractSimplePool {
 
   public verifyEvent: Nostr['verifyEvent']
   public enablePing: boolean | undefined
+  public enableReconnect: boolean | ((filters: Filter[]) => Filter[]) | undefined
   public trustedRelayURLs: Set<string> = new Set()
 
   private _WebSocket?: typeof WebSocket
@@ -41,6 +42,7 @@ export class AbstractSimplePool {
     this.verifyEvent = opts.verifyEvent
     this._WebSocket = opts.websocketImplementation
     this.enablePing = opts.enablePing
+    this.enableReconnect = opts.enableReconnect
   }
 
   async ensureRelay(url: string, params?: { connectionTimeout?: number }): Promise<AbstractRelay> {
@@ -52,6 +54,7 @@ export class AbstractSimplePool {
         verifyEvent: this.trustedRelayURLs.has(url) ? alwaysTrue : this.verifyEvent,
         websocketImplementation: this._WebSocket,
         enablePing: this.enablePing,
+        enableReconnect: this.enableReconnect,
       })
       relay.onclose = () => {
         this.relays.delete(url)

--- a/abstract-relay.ts
+++ b/abstract-relay.ts
@@ -116,11 +116,11 @@ export class AbstractRelay {
     const wasIntentional = this.closedIntentionally
     this.closedIntentionally = false // reset for next time
 
+    this.onclose?.()
+
     if (this.enableReconnect && !wasIntentional) {
       this.reconnect()
-      this.onclose?.()
     } else {
-      this.onclose?.()
       this.closeAllSubscriptions(reason)
     }
   }

--- a/abstract-relay.ts
+++ b/abstract-relay.ts
@@ -146,6 +146,10 @@ export class AbstractRelay {
       }
 
       this.ws.onopen = () => {
+        if (this.reconnectTimeoutHandle) {
+          clearTimeout(this.reconnectTimeoutHandle)
+          this.reconnectTimeoutHandle = undefined
+        }
         clearTimeout(this.connectionTimeoutHandle)
         this._connected = true
         this.reconnectAttempts = 0

--- a/abstract-relay.ts
+++ b/abstract-relay.ts
@@ -232,7 +232,9 @@ export class AbstractRelay {
         this.pingTimeoutHandle = setTimeout(() => this.pingpong(), this.pingFrequency)
       } else {
         // pingpong closing socket
-        this.ws?.close()
+        if (this.ws?.readyState === WebSocket.OPEN) {
+          this.ws?.close()
+        }
       }
     }
   }
@@ -432,7 +434,9 @@ export class AbstractRelay {
     this.closeAllSubscriptions('relay connection closed by us')
     this._connected = false
     this.onclose?.()
-    this.ws?.close()
+    if (this.ws?.readyState === WebSocket.OPEN) {
+      this.ws?.close()
+    }
   }
 
   // this is the function assigned to this.ws.onmessage

--- a/abstract-relay.ts
+++ b/abstract-relay.ts
@@ -7,8 +7,6 @@ import { Queue, normalizeURL } from './utils.ts'
 import { makeAuthEvent } from './nip42.ts'
 import { yieldThread } from './helpers.ts'
 
-const resubscribeBackoff = [10000, 10000, 10000, 20000, 20000, 30000, 60000]
-
 type RelayWebSocket = WebSocket & {
   ping?(): void
   on?(event: 'pong', listener: () => void): any
@@ -40,6 +38,7 @@ export class AbstractRelay {
   public publishTimeout: number = 4400
   public pingFrequency: number = 20000
   public pingTimeout: number = 20000
+  public resubscribeBackoff: number[] = [10000, 10000, 10000, 20000, 20000, 30000, 60000]
   public openSubs: Map<string, Subscription> = new Map()
   public enablePing: boolean | undefined
   public enableReconnect: boolean | ((filters: Filter[]) => Filter[])
@@ -97,7 +96,7 @@ export class AbstractRelay {
   }
 
   private async reconnect(): Promise<void> {
-    const backoff = resubscribeBackoff[Math.min(this.reconnectAttempts, resubscribeBackoff.length - 1)]
+    const backoff = this.resubscribeBackoff[Math.min(this.reconnectAttempts, this.resubscribeBackoff.length - 1)]
     this.reconnectAttempts++
 
     this.reconnectTimeoutHandle = setTimeout(async () => {

--- a/abstract-relay.ts
+++ b/abstract-relay.ts
@@ -222,7 +222,6 @@ export class AbstractRelay {
         setTimeout(() => this.pingpong(), this.pingFrequency)
       } else {
         // pingpong closing socket
-        this.closeAllSubscriptions('pingpong timed out')
         this.ws?.close()
       }
     }

--- a/abstract-relay.ts
+++ b/abstract-relay.ts
@@ -186,7 +186,7 @@ export class AbstractRelay {
   private async waitForPingPong() {
     return new Promise((res, err) => {
       // listen for pong
-      ;(this.ws && this.ws.on && this.ws.on('pong', () => res(true))) || err("ws can't listen for pong")
+      ;(this.ws && this.ws.on) ? this.ws.on('pong', () => res(true)) : err("ws can't listen for pong")
       // send a ping
       this.ws && this.ws.ping && this.ws.ping()
     })

--- a/abstract-relay.ts
+++ b/abstract-relay.ts
@@ -223,8 +223,6 @@ export class AbstractRelay {
       } else {
         // pingpong closing socket
         this.closeAllSubscriptions('pingpong timed out')
-        this._connected = false
-        this.onclose?.()
         this.ws?.close()
       }
     }

--- a/pool.test.ts
+++ b/pool.test.ts
@@ -253,6 +253,120 @@ test('ping-pong timeout in pool', async () => {
   expect(closed).toBeTrue()
 })
 
+test('reconnect on disconnect in pool', async () => {
+  const mockRelay = mockRelays[0]
+  pool = new SimplePool({ enablePing: true, enableReconnect: true })
+  const relay = await pool.ensureRelay(mockRelay.url)
+  relay.pingTimeout = 50
+  relay.pingFrequency = 50
+  relay.resubscribeBackoff = [50, 100]
+
+  let closes = 0
+  relay.onclose = () => {
+    closes++
+  }
+
+  expect(relay.connected).toBeTrue()
+
+  // wait for the first ping to succeed
+  await new Promise(resolve => setTimeout(resolve, 75))
+  expect(closes).toBe(0)
+
+  // now make it unresponsive
+  mockRelay.unresponsive = true
+
+  // wait for the second ping to fail, which will trigger a close
+  await new Promise(resolve => {
+    const interval = setInterval(() => {
+      if (closes > 0) {
+        clearInterval(interval)
+        resolve(null)
+      }
+    }, 10)
+  })
+  expect(closes).toBe(1)
+  expect(relay.connected).toBeFalse()
+
+  // now make it responsive again
+  mockRelay.unresponsive = false
+
+  // wait for reconnect
+  await new Promise(resolve => {
+    const interval = setInterval(() => {
+      if (relay.connected) {
+        clearInterval(interval)
+        resolve(null)
+      }
+    }, 10)
+  })
+
+  expect(relay.connected).toBeTrue()
+  expect(closes).toBe(1)
+})
+
+test('reconnect with filter update in pool', async () => {
+  const mockRelay = mockRelays[0]
+  const newSince = Math.floor(Date.now() / 1000)
+  pool = new SimplePool({
+    enablePing: true,
+    enableReconnect: filters => {
+      return filters.map(f => ({ ...f, since: newSince }))
+    },
+  })
+  const relay = await pool.ensureRelay(mockRelay.url)
+  relay.pingTimeout = 50
+  relay.pingFrequency = 50
+  relay.resubscribeBackoff = [50, 100]
+
+  let closes = 0
+  relay.onclose = () => {
+    closes++
+  }
+
+  expect(relay.connected).toBeTrue()
+
+  const sub = relay.subscribe([{ kinds: [1], since: 0 }], {})
+  expect(sub.filters[0].since).toBe(0)
+
+  // wait for the first ping to succeed
+  await new Promise(resolve => setTimeout(resolve, 75))
+  expect(closes).toBe(0)
+
+  // now make it unresponsive
+  mockRelay.unresponsive = true
+
+  // wait for the second ping to fail, which will trigger a close
+  await new Promise(resolve => {
+    const interval = setInterval(() => {
+      if (closes > 0) {
+        clearInterval(interval)
+        resolve(null)
+      }
+    }, 10)
+  })
+  expect(closes).toBe(1)
+  expect(relay.connected).toBeFalse()
+
+  // now make it responsive again
+  mockRelay.unresponsive = false
+
+  // wait for reconnect
+  await new Promise(resolve => {
+    const interval = setInterval(() => {
+      if (relay.connected) {
+        clearInterval(interval)
+        resolve(null)
+      }
+    }, 10)
+  })
+
+  expect(relay.connected).toBeTrue()
+  expect(closes).toBe(1)
+
+  // check if filter was updated
+  expect(sub.filters[0].since).toBe(newSince)
+})
+
 test('track relays when publishing', async () => {
   let event1 = finalizeEvent(
     {

--- a/pool.test.ts
+++ b/pool.test.ts
@@ -325,7 +325,7 @@ test('reconnect with filter update in pool', async () => {
 
   expect(relay.connected).toBeTrue()
 
-  const sub = relay.subscribe([{ kinds: [1], since: 0 }], {})
+  const sub = relay.subscribe([{ kinds: [1], since: 0 }], { onevent: () => {} })
   expect(sub.filters[0].since).toBe(0)
 
   // wait for the first ping to succeed

--- a/pool.ts
+++ b/pool.ts
@@ -1,7 +1,7 @@
 /* global WebSocket */
 
 import { verifyEvent } from './pure.ts'
-import { AbstractSimplePool } from './abstract-pool.ts'
+import { AbstractSimplePool, type AbstractPoolConstructorOptions } from './abstract-pool.ts'
 
 var _WebSocket: typeof WebSocket
 
@@ -14,7 +14,7 @@ export function useWebSocketImplementation(websocketImplementation: any) {
 }
 
 export class SimplePool extends AbstractSimplePool {
-  constructor(options?: { enablePing?: boolean }) {
+  constructor(options?: Pick<AbstractPoolConstructorOptions, 'enablePing' | 'enableReconnect'>) {
     super({ verifyEvent, websocketImplementation: _WebSocket, ...options })
   }
 }

--- a/relay.test.ts
+++ b/relay.test.ts
@@ -148,3 +148,117 @@ test('ping-pong timeout', async () => {
   expect(relay.connected).toBeFalse()
   expect(closed).toBeTrue()
 })
+
+test('reconnect on disconnect', async () => {
+  const mockRelay = new MockRelay()
+  const relay = new Relay(mockRelay.url, { enablePing: true, enableReconnect: true })
+  relay.pingTimeout = 50
+  relay.pingFrequency = 50
+  relay.resubscribeBackoff = [50, 100] // short backoff for testing
+
+  let closes = 0
+  relay.onclose = () => {
+    closes++
+  }
+
+  await relay.connect()
+  expect(relay.connected).toBeTrue()
+
+  // wait for the first ping to succeed
+  await new Promise(resolve => setTimeout(resolve, 75))
+  expect(closes).toBe(0)
+
+  // now make it unresponsive
+  mockRelay.unresponsive = true
+
+  // wait for the second ping to fail, which will trigger a close
+  await new Promise(resolve => {
+    const interval = setInterval(() => {
+      if (closes > 0) {
+        clearInterval(interval)
+        resolve(null)
+      }
+    }, 10)
+  })
+  expect(closes).toBe(1)
+  expect(relay.connected).toBeFalse()
+
+  // now make it responsive again
+  mockRelay.unresponsive = false
+
+  // wait for reconnect
+  await new Promise(resolve => {
+    const interval = setInterval(() => {
+      if (relay.connected) {
+        clearInterval(interval)
+        resolve(null)
+      }
+    }, 10)
+  })
+
+  expect(relay.connected).toBeTrue()
+  expect(closes).toBe(1) // should not have closed again
+})
+
+test('reconnect with filter update', async () => {
+  const mockRelay = new MockRelay()
+  const newSince = Math.floor(Date.now() / 1000)
+  const relay = new Relay(mockRelay.url, {
+    enablePing: true,
+    enableReconnect: filters => {
+      return filters.map(f => ({ ...f, since: newSince }))
+    },
+  })
+  relay.pingTimeout = 50
+  relay.pingFrequency = 50
+  relay.resubscribeBackoff = [50, 100]
+
+  let closes = 0
+  relay.onclose = () => {
+    closes++
+  }
+
+  await relay.connect()
+  expect(relay.connected).toBeTrue()
+
+  const sub = relay.subscribe([{ kinds: [1], since: 0 }], {})
+  expect(sub.filters[0].since).toBe(0)
+
+  // wait for the first ping to succeed
+  await new Promise(resolve => setTimeout(resolve, 75))
+  expect(closes).toBe(0)
+
+  // now make it unresponsive
+  mockRelay.unresponsive = true
+
+  // wait for the second ping to fail, which will trigger a close
+  await new Promise(resolve => {
+    const interval = setInterval(() => {
+      if (closes > 0) {
+        clearInterval(interval)
+        resolve(null)
+      }
+    }, 10)
+  })
+  expect(closes).toBe(1)
+  expect(relay.connected).toBeFalse()
+
+  // now make it responsive again
+  mockRelay.unresponsive = false
+
+  // wait for reconnect
+  await new Promise(resolve => {
+    const interval = setInterval(() => {
+      if (relay.connected) {
+        clearInterval(interval)
+        resolve(null)
+      }
+    }, 10)
+  })
+
+  expect(relay.connected).toBeTrue()
+  expect(closes).toBe(1)
+
+  // check if filter was updated
+  expect(sub.filters[0].since).toBe(newSince)
+})

--- a/relay.test.ts
+++ b/relay.test.ts
@@ -221,7 +221,7 @@ test('reconnect with filter update', async () => {
   await relay.connect()
   expect(relay.connected).toBeTrue()
 
-  const sub = relay.subscribe([{ kinds: [1], since: 0 }], {})
+  const sub = relay.subscribe([{ kinds: [1], since: 0 }], { onevent: () => {} })
   expect(sub.filters[0].since).toBe(0)
 
   // wait for the first ping to succeed

--- a/relay.ts
+++ b/relay.ts
@@ -14,12 +14,12 @@ export function useWebSocketImplementation(websocketImplementation: any) {
 }
 
 export class Relay extends AbstractRelay {
-  constructor(url: string) {
-    super(url, { verifyEvent, websocketImplementation: _WebSocket })
+  constructor(url: string, options?: { enablePing?: boolean }) {
+    super(url, { verifyEvent, websocketImplementation: _WebSocket, ...options })
   }
 
-  static async connect(url: string): Promise<Relay> {
-    const relay = new Relay(url)
+  static async connect(url: string, options?: { enablePing?: boolean }): Promise<Relay> {
+    const relay = new Relay(url, options)
     await relay.connect()
     return relay
   }

--- a/relay.ts
+++ b/relay.ts
@@ -1,7 +1,7 @@
 /* global WebSocket */
 
 import { verifyEvent } from './pure.ts'
-import { AbstractRelay } from './abstract-relay.ts'
+import { AbstractRelay, type AbstractRelayConstructorOptions } from './abstract-relay.ts'
 
 var _WebSocket: typeof WebSocket
 
@@ -14,11 +14,14 @@ export function useWebSocketImplementation(websocketImplementation: any) {
 }
 
 export class Relay extends AbstractRelay {
-  constructor(url: string, options?: { enablePing?: boolean }) {
+  constructor(url: string, options?: Pick<AbstractRelayConstructorOptions, 'enablePing' | 'enableReconnect'>) {
     super(url, { verifyEvent, websocketImplementation: _WebSocket, ...options })
   }
 
-  static async connect(url: string, options?: { enablePing?: boolean }): Promise<Relay> {
+  static async connect(
+    url: string,
+    options?: Pick<AbstractRelayConstructorOptions, 'enablePing' | 'enableReconnect'>,
+  ): Promise<Relay> {
     const relay = new Relay(url, options)
     await relay.connect()
     return relay

--- a/test-helpers.ts
+++ b/test-helpers.ts
@@ -26,6 +26,7 @@ export class MockRelay {
   public url: string
   public secretKeys: Uint8Array[]
   public preloadedEvents: Event[]
+  public unresponsive: boolean = false
 
   constructor(url?: string | undefined) {
     serial++
@@ -48,6 +49,7 @@ export class MockRelay {
       let subs: { [subId: string]: { conn: any; filters: Filter[] } } = {}
 
       conn.on('message', (message: string) => {
+        if (this.unresponsive) return
         const data = JSON.parse(message)
 
         switch (data[0]) {


### PR DESCRIPTION
This PR adds a new flag `enableReconnect` which turns on an exponential-backoff reconnection sequence for relay subscriptions. When a relay disconnects, reconnection will be attempted with a delay that gets longer with each attempt.

If `enableReconnect` is set to a callback function it will be called when reconnection occurs and passed the current subscription. This can be used to modify the subscription filters or e.g. the `since` parameter to fetch only newer events. The updated subscription will then be used.

This PR also:

- Introduces fixes and improvements for `enablePing` and incorporates #506 with more of the same.
- Introduces basic tests for the ping and reconnect flags.

Here's a simple HTML file test: [reconnect-test.html.zip](https://github.com/user-attachments/files/22582050/reconnect-test.html.zip)

Fixes #491.