### PR TITLE
fix(relay): set _connected = false before closeAllSubscriptions() in close()

### DIFF
--- a/abstract-relay.ts
+++ b/abstract-relay.ts
@@ -373,8 +373,8 @@ export class AbstractRelay {
       clearInterval(this.pingIntervalHandle)
       this.pingIntervalHandle = undefined
     }
-    this.closeAllSubscriptions('relay connection closed by us')
     this._connected = false
+    this.closeAllSubscriptions('relay connection closed by us')
     this.idleSince = undefined
     this.onclose?.()
     if (this.ws?.readyState === this._WebSocket.OPEN) {


### PR DESCRIPTION
close() was setting _connected = false after closeAllSubscriptions(), which meant each sub still saw the relay as connected and tried to send CLOSE frames. Those sends get queued as microtasks, but by the time they run the socket is already closing, so you get a bunch of "WebSocket is already in CLOSING or CLOSED state" warnings.

handleHardClose() already gets this order right — this just makes close() consistent with that.

Test results: 306/311 pass, identical before and after the fix. The 5 failures are pre-existing network-dependent tests (reconnect on disconnect, ping-pong timeout, negentropy sync) that rely on live relay connectivity and are unrelated to this change.