### PR TITLE
fix: window.printer is undefined in AbstractRelay._onmessage

### DIFF
--- a/abstract-relay.ts
+++ b/abstract-relay.ts
@@ -487,8 +487,12 @@ export class AbstractRelay {
         }
       }
     } catch (err) {
-      const [_, __, event] = JSON.parse(json)
-      ;(window as any).printer.maybe(event.pubkey, ':: caught err', event, this.url, err)
+      try {
+        const [_, __, event] = JSON.parse(json)
+        console.warn(`[nostr] relay ${this.url} error processing message:`, err, event)
+      } catch (_) {
+        console.warn(`[nostr] relay ${this.url} error processing message:`, err)
+      }
       return
     }
   }


### PR DESCRIPTION
When any relay message processing throws an error in _onmessage, the catch block calls `(window as any).printer.maybe(...)`. Since window.printer is never defined, this produces:
`TypeError: can't access property "maybe", window.printer is undefined`

This swallows the original error entirely and replaces it with an unrelated crash, making relay issues impossible to debug.
Additionally, the catch block calls `JSON.parse(json)` a second time without protection -- if the original error was caused by malformed JSON, this would throw again.