### PR TITLE
feat(nip46): add skipSwitchRelays option to BunkerSignerParams

### DIFF
--- a/nip46.ts
+++ b/nip46.ts
@@ -115,6 +115,8 @@ export function createNostrConnectURI(params: NostrConnectParams): string {
 export type BunkerSignerParams = {
   pool?: AbstractSimplePool
   onauth?: (url: string) => void
+  /** Skip automatic switchRelays() call in fromURI. Useful when you want to call it manually at your own pace. */
+  skipSwitchRelays?: boolean
 }
 
 export class BunkerSigner implements Signer {
@@ -220,7 +222,9 @@ export class BunkerSigner implements Signer {
                 signer.setupSubscription()
 
                 success = true
-                await Promise.race([new Promise(resolve => setTimeout(resolve, 1000)), signer.switchRelays()])
+                if (!bunkerParams.skipSwitchRelays) {
+                  await Promise.race([new Promise(resolve => setTimeout(resolve, 1000)), signer.switchRelays()])
+                }
                 resolve(signer)
               }
             } catch (e) {


### PR DESCRIPTION
## Summary

Adds a `skipSwitchRelays` option to `BunkerSignerParams` that prevents the automatic `switchRelays()` call in `fromURI`. This is useful when users want to call `switchRelays` manually at their own pace.

## Problem

As described in #526, when `switchRelays` does not finish before the 1000ms timeout, the promise from `fromURI` resolves anyway, but `switchRelays` continues running and may overwrite subscriptions while other RPCs are inflight, causing timeouts.

## Solution

Add an optional `skipSwitchRelays?: boolean` flag to `BunkerSignerParams`. When set to `true`, the automatic `switchRelays()` call in `fromURI` is skipped, allowing users to call it manually when ready.

```typescript
const signer = await BunkerSigner.fromURI(
  clientSecretKey,
  connectionURI,
  { skipSwitchRelays: true }  // Skip automatic switchRelays
)

// Make immediate RPC calls without race condition
await signer.getPublicKey()

// Call switchRelays manually when ready
await signer.switchRelays()
```

Fixes #526