### PR TITLE
fix(nip42): catch SendingOnClosedConnection during automatic AUTH

### DIFF
--- a/abstract-relay.ts
+++ b/abstract-relay.ts
@@ -476,7 +476,14 @@ export class AbstractRelay {
         case 'AUTH': {
           this.challenge = data[1] as string
           if (this.onauth) {
-            this.auth(this.onauth)
+            this.auth(this.onauth).catch(err => {
+              // If the connection closed before auth could be sent, just ignore it.
+              // This is a race condition when relays close connections quickly
+              // (e.g., WoT-enforced relays that reject unknown pubkeys).
+              if (!(err instanceof SendingOnClosedConnection)) {
+                throw err // re-throw other errors
+              }
+            })
           }
           return
         }


### PR DESCRIPTION
## Summary

Fixes #531. When `automaticallyAuth` is configured and a relay closes the connection between sending the AUTH challenge and the client sending the signed response, the `SendingOnClosedConnection` error was propagating as an unhandled promise rejection.

This is a race condition that commonly occurs with relays that enforce WoT or whitelists — they accept the WebSocket, send an AUTH challenge, but close the connection before the client can respond.

## Changes

- Add `.catch()` handler to `this.auth(this.onauth)` call in the AUTH case handler
- Specifically catch `SendingOnClosedConnection` and suppress it (the connection is already closed, nothing useful to do)
- Other errors are re-thrown to maintain existing behavior

## Testing

This fix handles a race condition that is difficult to test deterministically, but the logic is straightforward: if we fail to send because the connection is closed, we silently ignore it rather than crashing the process.

## Context

This is my third PR to nostr-tools (previous: #529, #530 — both merged). I encountered this issue while building agent tooling that connects to multiple relays.