### PR TITLE
feat(nip47): support multiple relays in parseConnectionString

### DIFF
--- a/nip47.test.ts
+++ b/nip47.test.ts
@@ -8,20 +8,33 @@ describe('parseConnectionString', () => {
   test('returns pubkey, relay, and secret if connection string has double slash', () => {
     const connectionString =
       'nostr+walletconnect://b889ff5b1513b641e2a139f661a661364979c5beee91842f8f0ef42ab558e9d4?relay=wss%3A%2F%2Frelay.damus.io&secret=71a8c14c1407c113601079c4302dab36460f0ccd0ad506f1f2dc73b5100e4f3c'
-    const { pubkey, relay, secret } = parseConnectionString(connectionString)
+    const { pubkey, relay, relays, secret } = parseConnectionString(connectionString)
 
     expect(pubkey).toBe('b889ff5b1513b641e2a139f661a661364979c5beee91842f8f0ef42ab558e9d4')
     expect(relay).toBe('wss://relay.damus.io')
+    expect(relays).toEqual(['wss://relay.damus.io'])
     expect(secret).toBe('71a8c14c1407c113601079c4302dab36460f0ccd0ad506f1f2dc73b5100e4f3c')
   })
 
   test('returns pubkey, relay, and secret if connection string is valid', () => {
     const connectionString =
       'nostr+walletconnect:b889ff5b1513b641e2a139f661a661364979c5beee91842f8f0ef42ab558e9d4?relay=wss%3A%2F%2Frelay.damus.io&secret=71a8c14c1407c113601079c4302dab36460f0ccd0ad506f1f2dc73b5100e4f3c'
-    const { pubkey, relay, secret } = parseConnectionString(connectionString)
+    const { pubkey, relay, relays, secret } = parseConnectionString(connectionString)
 
     expect(pubkey).toBe('b889ff5b1513b641e2a139f661a661364979c5beee91842f8f0ef42ab558e9d4')
     expect(relay).toBe('wss://relay.damus.io')
+    expect(relays).toEqual(['wss://relay.damus.io'])
+    expect(secret).toBe('71a8c14c1407c113601079c4302dab36460f0ccd0ad506f1f2dc73b5100e4f3c')
+  })
+
+  test('returns multiple relays when connection string has multiple relay params', () => {
+    const connectionString =
+      'nostr+walletconnect://b889ff5b1513b641e2a139f661a661364979c5beee91842f8f0ef42ab558e9d4?relay=wss%3A%2F%2Frelay.damus.io&relay=wss%3A%2F%2Fnos.lol&secret=71a8c14c1407c113601079c4302dab36460f0ccd0ad506f1f2dc73b5100e4f3c'
+    const { pubkey, relay, relays, secret } = parseConnectionString(connectionString)
+
+    expect(pubkey).toBe('b889ff5b1513b641e2a139f661a661364979c5beee91842f8f0ef42ab558e9d4')
+    expect(relay).toBe('wss://relay.damus.io')
+    expect(relays).toEqual(['wss://relay.damus.io', 'wss://nos.lol'])
     expect(secret).toBe('71a8c14c1407c113601079c4302dab36460f0ccd0ad506f1f2dc73b5100e4f3c')
   })
 

--- a/nip47.ts
+++ b/nip47.ts
@@ -4,21 +4,23 @@ import { encrypt } from './nip04.ts'
 
 interface NWCConnection {
   pubkey: string
+  /** @deprecated Use `relays` instead. This returns only the first relay. */
   relay: string
+  relays: string[]
   secret: string
 }
 
 export function parseConnectionString(connectionString: string): NWCConnection {
   const { host, pathname, searchParams } = new URL(connectionString)
   const pubkey = pathname || host
-  const relay = searchParams.get('relay')
+  const relays = searchParams.getAll('relay')
   const secret = searchParams.get('secret')
 
-  if (!pubkey || !relay || !secret) {
+  if (!pubkey || relays.length === 0 || !secret) {
     throw new Error('invalid connection string')
   }
 
-  return { pubkey, relay, secret }
+  return { pubkey, relay: relays[0], relays, secret }
 }
 
 export async function makeNwcRequestEvent(

--- a/pool.test.ts
+++ b/pool.test.ts
@@ -407,10 +407,12 @@ test('oninvalidevent is called through the pool for invalid events', async done 
   })
 
   const sk = generateSecretKey()
-  const wrongFieldTypeEvent = [finalizeEvent(
-    { kind: 1, content: 'hello', created_at: Math.floor(Date.now() / 1000), tags: [] },
-    sk,
-  )].map(v => { (v as any).kind = '1'; return v })[0]
+  const wrongFieldTypeEvent = [
+    finalizeEvent({ kind: 1, content: 'hello', created_at: Math.floor(Date.now() / 1000), tags: [] }, sk),
+  ].map(v => {
+    ;(v as any).kind = '1'
+    return v
+  })[0]
 
   relay._onmessage({ data: JSON.stringify(['EVENT', sub.id, wrongFieldTypeEvent]) } as MessageEvent)
 })

--- a/relay.test.ts
+++ b/relay.test.ts
@@ -353,15 +353,20 @@ test('oninvalidevent is called for malformed events', async done => {
   })
 
   const sk = generateSecretKey()
-  const wrongFieldTypeEvent = [finalizeEvent(
-    {
-      kind: 1,
-      content: 'content',
-      created_at: 0,
-      tags: [],
-    },
-    sk
-  )].map(v => { (v as any).kind = '1'; return v })[0]
+  const wrongFieldTypeEvent = [
+    finalizeEvent(
+      {
+        kind: 1,
+        content: 'content',
+        created_at: 0,
+        tags: [],
+      },
+      sk,
+    ),
+  ].map(v => {
+    ;(v as any).kind = '1'
+    return v
+  })[0]
 
   relay._onmessage({ data: JSON.stringify(['EVENT', sub.id, wrongFieldTypeEvent]) } as MessageEvent)
 })


### PR DESCRIPTION
## Summary

`parseConnectionString` now returns all relay URLs from NWC connection strings, not just the first one.

## Changes

- Added `relays: string[]` field to `NWCConnection` interface
- `relay` field kept for backward compatibility (marked `@deprecated`)
- Uses `searchParams.getAll("relay")` instead of `searchParams.get("relay")`
- Added test for multiple relay params
- All existing tests pass unchanged

## Backward Compatibility

Fully backward compatible. Existing code using `relay` continues to work (returns first relay). New code can use `relays` to get all of them.

Fixes #494