### PR TITLE
export compareEvents

### DIFF
--- a/core.test.ts
+++ b/core.test.ts
@@ -1,5 +1,21 @@
 import { test, expect } from 'bun:test'
-import { sortEvents } from './core.ts'
+import { compareEvents, sortEvents } from './core.ts'
+
+test('compareEvents', () => {
+  const event = {
+    id: 'abc123',
+    pubkey: 'key1',
+    created_at: 1620000000,
+    kind: 1,
+    tags: [],
+    content: 'Hello',
+    sig: 'sig1',
+  }
+
+  expect(compareEvents(event, { ...event, created_at: 1610000000 })).toBeLessThan(0)
+  expect(compareEvents(event, { ...event, id: 'abc124' })).toBeLessThan(0)
+  expect(compareEvents(event, { ...event })).toBe(0)
+})
 
 test('sortEvents', () => {
   const events = [

--- a/core.ts
+++ b/core.ts
@@ -53,15 +53,21 @@ export function validateEvent<T>(event: T): event is T & UnsignedEvent {
 }
 
 /**
+ * Compare events in reverse-chronological order by the `created_at` timestamp,
+ * and then by the event `id` (lexicographically) in case of ties.
+ */
+export function compareEvents(a: Event, b: Event): number {
+  if (a.created_at !== b.created_at) {
+    return b.created_at - a.created_at
+  }
+  return a.id.localeCompare(b.id)
+}
+
+/**
  * Sort events in reverse-chronological order by the `created_at` timestamp,
  * and then by the event `id` (lexicographically) in case of ties.
  * This mutates the array.
  */
 export function sortEvents(events: Event[]): Event[] {
-  return events.sort((a: NostrEvent, b: NostrEvent): number => {
-    if (a.created_at !== b.created_at) {
-      return b.created_at - a.created_at
-    }
-    return a.id.localeCompare(b.id)
-  })
+  return events.sort(compareEvents)
 }


### PR DESCRIPTION
`sortEvents()` already contains a useful event comparison rule, but currently it can only be reused by sorting an array.

There are cases where consumers need to compare two events directly instead. For example, when maintaining a cache of replaceable events, a consumer may need to decide whether an incoming event should replace the currently stored event without creating and sorting a temporary array.

This PR extracts the comparison logic from `sortEvents()` into an exported `compareEvents()` function.

`sortEvents()` now delegates to `compareEvents()`, so its existing behavior is unchanged.

Example:

```ts
if (compareEvents(incoming, current) < 0) {
  current = incoming
}