### PR TITLE
fix(pool): SimplePool.publish() should reject, not resolve, on connection failure

### DIFF
--- a/abstract-pool.ts
+++ b/abstract-pool.ts
@@ -407,7 +407,7 @@ export class AbstractSimplePool {
         })
       } catch (err) {
         this.onRelayConnectionFailure?.(url)
-        return String('connection failure: ' + String(err))
+        return Promise.reject('connection failure: ' + String(err))
       }
 
       return r

--- a/pool.test.ts
+++ b/pool.test.ts
@@ -389,6 +389,32 @@ test('track relays when publishing', async () => {
   expect(pool.seenOn.get(event2.id)).toBeUndefined()
 })
 
+test('publish() rejects (does not resolve) when a relay is unreachable', async () => {
+  // ensureRelay()'s failure was previously swallowed and turned into a
+  // *resolved* string ("connection failure: ..."), so callers using the
+  // documented `Promise.any(pool.publish(...))` pattern (or any other
+  // fulfilled-vs-rejected check) would see success even when every relay
+  // was unreachable. It must reject like the pool's other early failure
+  // paths (duplicate url, allowConnectingToRelay) already do.
+  let event = finalizeEvent(
+    {
+      kind: 1,
+      created_at: Math.floor(Date.now() / 1000),
+      tags: [],
+      content: 'hello',
+    },
+    generateSecretKey(),
+  )
+
+  const unreachable = 'wss://nobody-is-listening.invalid.mock/nothing'
+  const [settled] = await Promise.allSettled(pool.publish([unreachable], event))
+
+  expect(settled.status).toBe('rejected')
+  if (settled.status === 'rejected') {
+    expect(String(settled.reason)).toContain('connection failure')
+  }
+})
+
 test('oninvalidevent is called through the pool for invalid events', async done => {
   const mockRelay = mockRelays[0]
   const relay = await pool.ensureRelay(mockRelay.url)


### PR DESCRIPTION
## The bug

In `abstract-pool.ts`'s `publish()`, two of the three early-exit failure paths correctly `Promise.reject()`:

```ts
if (arr.indexOf(url) !== i) {
  return Promise.reject('duplicate url')
}
if (this.allowConnectingToRelay?.(url, ['write', event]) === false) {
  return Promise.reject('connection skipped by allowConnectingToRelay')
}
```

but the third — a real connection failure from `ensureRelay()` — instead returns a **fulfilled** string:

```ts
} catch (err) {
  this.onRelayConnectionFailure?.(url)
  return String('connection failure: ' + String(err))  // resolves, doesn't reject
}
```

Since the per-relay promise fulfills either way, anything that checks fulfilled-vs-rejected without inspecting the resolved value — including this repo's own README-documented pattern, `await Promise.any(pool.publish(relays, event))` — reports success even when **every relay connection failed**. `Promise.any` only cares whether a promise settled as fulfilled, never what it resolved to.

I hit this for real: a caller doing `Promise.allSettled(pool.publish(...)).some(r => r.status === 'fulfilled')` to detect "did at least one relay accept this" got `true` for a batch where every relay was unreachable.

## The fix

One line: `return Promise.reject(...)` instead of `return String(...)`, matching the other two failure paths in the same function.

## Testing

Added a test in `pool.test.ts` that publishes to an unreachable mock relay URL and asserts the settled result is `rejected`, not `fulfilled` — confirmed failing against unpatched `master` (reproduced first, then fixed) and passing after the fix. Full suite run: 355/357 pass; the 2 failures are pre-existing and unrelated (`nip77`'s live-network test against `wss://relay.damus.io`, unreachable from a sandboxed CI-like environment, and the timing-sensitive `ping-pong timeout in pool` test) — both confirmed failing identically on a clean, unmodified checkout of `master` before I touched anything.

`eslint`/`prettier` clean on both changed files.