### PR TITLE
fix(nip98): reject tokens whose created_at is in the future

### DIFF
--- a/nip98.test.ts
+++ b/nip98.test.ts
@@ -136,6 +136,17 @@ describe('validateToken', () => {
     expect(isTokenValid).rejects.toThrow(Error)
   })
 
+  test('throws an error for an event timestamp in the future', async () => {
+    const sk = generateSecretKey()
+    const invalidToken = await getToken('http://test.com', 'get', e => {
+      e.created_at = Math.round(Date.now() / 1000) + 3600
+      return finalizeEvent(e, sk)
+    })
+    const isTokenValid = validateToken(invalidToken, 'http://test.com', 'get')
+
+    expect(isTokenValid).rejects.toThrow(Error)
+  })
+
   test('throws an error for invalid url', async () => {
     const sk = generateSecretKey()
     const token = await getToken('http://test.com', 'get', e => finalizeEvent(e, sk))
@@ -235,6 +246,16 @@ describe('validateEventTimestamp', () => {
     const token = await getToken('http://test.com', 'get', e => finalizeEvent(e, sk), true)
     const unpackedEvent: Event = await unpackEventFromToken(token)
     unpackedEvent.created_at = 0
+    const isEventTimestampValid = validateEventTimestamp(unpackedEvent)
+
+    expect(isEventTimestampValid).toBe(false)
+  })
+
+  test('returns false for a timestamp in the future', async () => {
+    const sk = generateSecretKey()
+    const token = await getToken('http://test.com', 'get', e => finalizeEvent(e, sk), true)
+    const unpackedEvent: Event = await unpackEventFromToken(token)
+    unpackedEvent.created_at = Math.round(Date.now() / 1000) + 3600
     const isEventTimestampValid = validateEventTimestamp(unpackedEvent)
 
     expect(isEventTimestampValid).toBe(false)

--- a/nip98.ts
+++ b/nip98.ts
@@ -87,14 +87,16 @@ export async function unpackEventFromToken(token: string): Promise<Event> {
 /**
  * Validates the timestamp of an event.
  * @param event - The event object to validate.
- * @returns A boolean indicating whether the event timestamp is within the last 60 seconds.
+ * @returns A boolean indicating whether the event timestamp is within 60 seconds of now.
  */
 export function validateEventTimestamp(event: Event): boolean {
   if (!event.created_at) {
     return false
   }
 
-  return Math.round(new Date().getTime() / 1000) - event.created_at < 60
+  // the comparison has to be absolute: a `created_at` in the future produces a
+  // negative difference, which would otherwise satisfy the check forever.
+  return Math.abs(Math.round(new Date().getTime() / 1000) - event.created_at) < 60
 }
 
 /**


### PR DESCRIPTION
`validateEventTimestamp()` does:

```ts
return Math.round(new Date().getTime() / 1000) - event.created_at < 60
```

For a `created_at` ahead of now the difference goes negative, which satisfies `< 60`. A token signed with `created_at = now + 10^9` therefore validates forever.

NIP-98 has no nonce and no seen-token cache, so that 60 second window is the only replay protection there is — and right now it only closes on one side. Anyone who captures such a token, or mints one if they are the client, can replay it indefinitely.

Fixed by comparing the absolute difference, so the window is ±60s.

Two tests added, both fail on master.