### PR TITLE
Add React Native section to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -459,6 +459,29 @@ summary for relay read message and verify event
 </script>
 ```
 
+### Using it with React Native
+
+React Native requires polyfills:
+
+```sh
+npm install react-native-get-random-values text-encoding-polyfill react-native-url-polyfill
+```
+
+Import the polyfills at the very top of your entry file (`index.js`), **before** anything that imports `nostr-tools`:
+
+```js
+import 'react-native-get-random-values'
+import 'text-encoding-polyfill'
+import 'react-native-url-polyfill/auto'
+
+import { AppRegistry } from 'react-native'
+// ...
+```
+
+Future versions of React Native may implement these features natively, allowing the polyfills to be removed.
+
+Note: `nostr-tools/wasm` will not work with React Native because it does not have WebAssembly support.
+
 ## Plumbing
 
 To develop `@nostr/tools`, install [`just`](https://just.systems/) and run `just -l` to see commands available.


### PR DESCRIPTION
Fixes https://github.com/nbd-wtf/nostr-tools/issues/80

React Native sucks. It doesn't support half of JavaScript.

But people have been asking about it here for years, and I finally tried creating a React Native app myself and hit the same walls.

The solution isn't to change nostr-tools, which is already compatible with every other JS runtime. Instead the user should add polyfills to their own React Native app.

This just adds a section to the README with instructions on how to do it. I confirmed that after adding these polyfills nostr-tools can be used with React Native on an Android device.